### PR TITLE
fix: refactor user groups to permissions relation gf-78

### DIFF
--- a/apps/backend/src/db/migrations/20240829181900_fix_user_groups_to_permissions.ts
+++ b/apps/backend/src/db/migrations/20240829181900_fix_user_groups_to_permissions.ts
@@ -1,0 +1,44 @@
+import { type Knex } from "knex";
+
+const TABLE_NAME = "user_groups_to_permissions";
+
+const ColumnName = {
+	CREATED_AT: "created_at",
+	ID: "id",
+	PERMISSION_ID: "permission_id",
+	UPDATED_AT: "updated_at",
+	USER_GROUP_ID: "user_group_id",
+} as const;
+
+const PERMISSIONS_TABLE = "permissions";
+const USERS_TABLE = "users";
+
+function up(knex: Knex): Promise<void> {
+	return knex.schema.alterTable(TABLE_NAME, (table) => {
+		table.dropForeign([ColumnName.PERMISSION_ID]);
+		table
+			.integer(ColumnName.PERMISSION_ID)
+			.unsigned()
+			.notNullable()
+			.references("id")
+			.inTable(PERMISSIONS_TABLE)
+			.onDelete("CASCADE")
+			.alter();
+	});
+}
+
+function down(knex: Knex): Promise<void> {
+	return knex.schema.alterTable(TABLE_NAME, (table) => {
+		table.dropForeign([ColumnName.PERMISSION_ID]);
+		table
+			.integer(ColumnName.PERMISSION_ID)
+			.unsigned()
+			.notNullable()
+			.references("id")
+			.inTable(USERS_TABLE)
+			.onDelete("CASCADE")
+			.alter();
+	});
+}
+
+export { down, up };

--- a/apps/backend/src/db/migrations/20240829181900_fix_user_groups_to_permissions.ts
+++ b/apps/backend/src/db/migrations/20240829181900_fix_user_groups_to_permissions.ts
@@ -3,11 +3,7 @@ import { type Knex } from "knex";
 const TABLE_NAME = "user_groups_to_permissions";
 
 const ColumnName = {
-	CREATED_AT: "created_at",
-	ID: "id",
 	PERMISSION_ID: "permission_id",
-	UPDATED_AT: "updated_at",
-	USER_GROUP_ID: "user_group_id",
 } as const;
 
 const PERMISSIONS_TABLE = "permissions";


### PR DESCRIPTION
Created new migration to change FK user_groups_to_permissions.permission_id to reference permissions.id