### PR TITLE
fix: "No token provided" error message appears when navigating to the "Access Management" page gf-117

### DIFF
--- a/apps/frontend/src/modules/users/users-api.ts
+++ b/apps/frontend/src/modules/users/users-api.ts
@@ -22,7 +22,7 @@ class UserApi extends BaseHTTPApi {
 			this.getFullEndpoint(UsersApiPath.ROOT, {}),
 			{
 				contentType: ContentType.JSON,
-				hasAuth: false,
+				hasAuth: true,
 				method: "GET",
 			},
 		);


### PR DESCRIPTION
Message was appearing because we couldn't get users due to lack of authorization token in the request. 
Solution: in `getAll` method of `UserApi`, while calling `load`, we need to pass `true` to `hasAuth` property of `options`, in order to include token to the request.