### PR TITLE
fix: Inconsistent line height of the Back to home text within the button on the Not fount page gf-156

### DIFF
--- a/apps/frontend/src/libs/components/button/styles.module.css
+++ b/apps/frontend/src/libs/components/button/styles.module.css
@@ -1,4 +1,5 @@
 .button {
+	align-content: center;
 	min-height: 44px;
 	padding: 10px 16px;
 	font-family: Inter, sans-serif;


### PR DESCRIPTION
Done: 

- centralized text alignment on the button

Preview:
![image](https://github.com/user-attachments/assets/27fdbd0d-8943-447b-bb0d-ea986edd98c6)
