### PR TITLE
feat: scroll element must be shown at the right side of the table component gf-149

### DIFF
--- a/apps/frontend/src/libs/components/table/styles.module.css
+++ b/apps/frontend/src/libs/components/table/styles.module.css
@@ -1,3 +1,10 @@
+.table-container {
+	width: 100%;
+	overflow: hidden;
+	border: 1px solid var(--color-border-primary);
+	border-radius: 8px;
+}
+
 .table {
 	width: 100%;
 	font-family: Inter, sans-serif;
@@ -7,8 +14,6 @@
 	border-spacing: 0;
 	border-collapse: separate;
 	background-color: var(--color-background-secondary);
-	border: 1px solid var(--color-border-primary);
-	border-radius: 8px;
 }
 
 .table th,
@@ -29,6 +34,21 @@
 	font-weight: 500;
 	line-height: 120%;
 	color: var(--color-text-secondary);
+	background-color: var(--color-background-secondary);
+	border-bottom: 1px solid var(--color-border-primary);
+}
+
+.table tbody {
+	display: block;
+	max-height: 450px;
+	overflow-y: auto;
+}
+
+.table thead,
+.table tr {
+	display: table;
+	width: 100%;
+	table-layout: fixed;
 }
 
 .table tr:last-child td {

--- a/apps/frontend/src/libs/components/table/styles.module.css
+++ b/apps/frontend/src/libs/components/table/styles.module.css
@@ -16,20 +16,20 @@
 	background-color: var(--color-background-secondary);
 }
 
-.table th,
-.table td {
+.table .table-header,
+.table .table-data {
 	padding: 10px 20px;
 	text-align: left;
 	border-bottom: 1px solid var(--color-border-primary);
 }
 
-.table td {
+.table .table-data {
 	min-height: 60px;
 	font-weight: 400;
 	line-height: 150%;
 }
 
-.table th {
+.table .table-header {
 	min-height: 45px;
 	font-weight: 500;
 	line-height: 120%;
@@ -38,19 +38,19 @@
 	border-bottom: 1px solid var(--color-border-primary);
 }
 
-.table tbody {
+.table .table-body {
 	display: block;
 	max-height: 450px;
 	overflow-y: auto;
 }
 
-.table thead,
-.table tr {
+.table .table-head,
+.table .table-row {
 	display: table;
 	width: 100%;
 	table-layout: fixed;
 }
 
-.table tr:last-child td {
+.table .table-row:last-child .table-data {
 	border-bottom: none;
 }

--- a/apps/frontend/src/libs/components/table/table.tsx
+++ b/apps/frontend/src/libs/components/table/table.tsx
@@ -26,11 +26,11 @@ const Table = <T extends object>({
 	return (
 		<div className={styles["table-container"]}>
 			<table className={styles["table"]}>
-				<thead>
+				<thead className={styles["table-head"]}>
 					{table.getHeaderGroups().map((headerGroup) => (
-						<tr key={headerGroup.id}>
+						<tr className={styles["table-row"]} key={headerGroup.id}>
 							{headerGroup.headers.map((header) => (
-								<th key={header.id}>
+								<th className={styles["table-header"]} key={header.id}>
 									{flexRender(
 										header.column.columnDef.header,
 										header.getContext(),
@@ -40,11 +40,11 @@ const Table = <T extends object>({
 						</tr>
 					))}
 				</thead>
-				<tbody>
+				<tbody className={styles["table-body"]}>
 					{table.getRowModel().rows.map((row) => (
-						<tr key={row.id}>
+						<tr className={styles["table-row"]} key={row.id}>
 							{row.getVisibleCells().map((cell) => (
-								<td key={cell.id}>
+								<td className={styles["table-data"]} key={cell.id}>
 									{flexRender(cell.column.columnDef.cell, cell.getContext())}
 								</td>
 							))}

--- a/apps/frontend/src/libs/components/table/table.tsx
+++ b/apps/frontend/src/libs/components/table/table.tsx
@@ -24,33 +24,35 @@ const Table = <T extends object>({
 	});
 
 	return (
-		<table className={styles["table"]}>
-			<thead>
-				{table.getHeaderGroups().map((headerGroup) => (
-					<tr key={headerGroup.id}>
-						{headerGroup.headers.map((header) => (
-							<th key={header.id}>
-								{flexRender(
-									header.column.columnDef.header,
-									header.getContext(),
-								)}
-							</th>
-						))}
-					</tr>
-				))}
-			</thead>
-			<tbody>
-				{table.getRowModel().rows.map((row) => (
-					<tr key={row.id}>
-						{row.getVisibleCells().map((cell) => (
-							<td key={cell.id}>
-								{flexRender(cell.column.columnDef.cell, cell.getContext())}
-							</td>
-						))}
-					</tr>
-				))}
-			</tbody>
-		</table>
+		<div className={styles["table-container"]}>
+			<table className={styles["table"]}>
+				<thead>
+					{table.getHeaderGroups().map((headerGroup) => (
+						<tr key={headerGroup.id}>
+							{headerGroup.headers.map((header) => (
+								<th key={header.id}>
+									{flexRender(
+										header.column.columnDef.header,
+										header.getContext(),
+									)}
+								</th>
+							))}
+						</tr>
+					))}
+				</thead>
+				<tbody>
+					{table.getRowModel().rows.map((row) => (
+						<tr key={row.id}>
+							{row.getVisibleCells().map((cell) => (
+								<td key={cell.id}>
+									{flexRender(cell.column.columnDef.cell, cell.getContext())}
+								</td>
+							))}
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
 	);
 };
 


### PR DESCRIPTION
Added scroll to the table. The header of the table is sticking at the top, while body is moving. 
<img width="1210" alt="Screenshot 2024-09-03 at 18 21 13" src="https://github.com/user-attachments/assets/8324d5cc-4890-466f-aa67-1df3c40e43d6">
