### PR TITLE
fix: Font size of the "Profile" heading doesn`t match the design mockup gf-192

### DIFF
--- a/apps/frontend/src/pages/profile/profile.tsx
+++ b/apps/frontend/src/pages/profile/profile.tsx
@@ -10,7 +10,7 @@ const Profile = (): JSX.Element => {
 
 	return (
 		<PageLayout>
-			<div className={styles["profile-content"]}>
+			<div className={styles["profile-layout"]}>
 				<h1 className={styles["title"]}>Profile</h1>
 
 				<EditUserForm user={authenticatedUser as UserAuthResponseDto} />

--- a/apps/frontend/src/pages/profile/styles.module.css
+++ b/apps/frontend/src/pages/profile/styles.module.css
@@ -13,6 +13,6 @@
 .title {
 	margin: 0;
 	font-size: 30px;
+	font-weight: 600;
 	line-height: 120%;
-	word-break: break-word;
 }

--- a/apps/frontend/src/pages/profile/styles.module.css
+++ b/apps/frontend/src/pages/profile/styles.module.css
@@ -1,16 +1,18 @@
-.title {
-	margin-top: 0;
-	margin-bottom: 24px;
-}
-
-.profile-loader {
+.profile-layout {
 	display: flex;
-	flex: 1;
-	align-items: center;
-}
-
-.profile-content {
+	flex-direction: column;
+	gap: 24px;
+	align-items: flex-start;
 	width: 100%;
 	max-width: 800px;
+	padding: 0;
 	margin: 0 auto;
+	color: var(--color-text-primary);
+}
+
+.title {
+	margin: 0;
+	font-size: 30px;
+	line-height: 120%;
+	word-break: break-word;
 }


### PR DESCRIPTION
- fix title font size and add additional settings (line-height, word-break)
- change profile layout styles

![image](https://github.com/user-attachments/assets/b7f1ef24-82d7-43a2-853d-bc03d5d63808)

![image](https://github.com/user-attachments/assets/82e7c407-66d8-40aa-bd52-4b94f4722504)

