### PR TITLE
fix: inappropriate appearance of the scroll element at the Table component on Windows OS gf-197

### DIFF
--- a/apps/frontend/src/assets/css/scaffolding.css
+++ b/apps/frontend/src/assets/css/scaffolding.css
@@ -1,5 +1,7 @@
 * {
 	box-sizing: border-box;
+	scrollbar-width: thin;
+	scrollbar-color: var(--color-border-primary) var(--color-background-secondary);
 }
 
 body {
@@ -31,4 +33,21 @@ body {
 	clip-path: inset(100%);
 	white-space: nowrap;
 	border: 0;
+}
+
+::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+	background-color: var(--color-border-primary);
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background-color: var(--color-brand-primary);
+}
+
+::-webkit-scrollbar-track {
+	background: var(--color-background-secondary);
 }

--- a/apps/frontend/src/assets/css/scaffolding.css
+++ b/apps/frontend/src/assets/css/scaffolding.css
@@ -1,7 +1,5 @@
 * {
 	box-sizing: border-box;
-	scrollbar-width: thin;
-	scrollbar-color: var(--color-border-primary) var(--color-background-secondary);
 }
 
 body {
@@ -35,19 +33,24 @@ body {
 	border: 0;
 }
 
-::-webkit-scrollbar {
+html {
+	scrollbar-width: thin;
+	scrollbar-color: var(--color-border-primary) var(--color-background-secondary);
+}
+
+html::-webkit-scrollbar {
 	width: 8px;
 	height: 8px;
 }
 
-::-webkit-scrollbar-thumb {
+html::-webkit-scrollbar-thumb {
 	background-color: var(--color-border-primary);
 }
 
-::-webkit-scrollbar-thumb:hover {
+html::-webkit-scrollbar-thumb:hover {
 	background-color: var(--color-brand-primary);
 }
 
-::-webkit-scrollbar-track {
+html::-webkit-scrollbar-track {
 	background: var(--color-background-secondary);
 }


### PR DESCRIPTION
Added global styles for scroll element. As an example for styles I took the only scrollbar which is shown in design.
<img width="994" alt="Screenshot 2024-09-06 at 08 13 33" src="https://github.com/user-attachments/assets/f4d481ce-83b9-4082-b3db-0966ee50eb3c">
Here's how does scrollbar looks across different browsers on Mac:
Webkit browsers (Chrome, Safari, new Edge):
<img width="163" alt="Screenshot 2024-09-06 at 08 23 06" src="https://github.com/user-attachments/assets/65a10c3f-5cfc-4ea8-be3d-909011059f63">
Firefox:
<img width="183" alt="Screenshot 2024-09-06 at 08 24 04" src="https://github.com/user-attachments/assets/c969d3d6-3b08-4ed9-bb5d-6e7205f32a47">
They look a little bit different, because there is no ability to customise one in Firefox more than that.
Unfortunately, have no ability to test it on windows, but it should there too work.
