### PR TITLE
feat: Add a "No projects found" message when search field no results on the Projects page gf-187

### DIFF
--- a/apps/frontend/src/pages/projects/projects.tsx
+++ b/apps/frontend/src/pages/projects/projects.tsx
@@ -50,7 +50,7 @@ const Projects = (): JSX.Element => {
 		[dispatch],
 	);
 
-	const hasProject = projects.length === EMPTY_LENGTH;
+	const hasProject = projects.length !== EMPTY_LENGTH;
 
 	const {
 		isOpened: isCreateModalOpen,
@@ -122,7 +122,7 @@ const Projects = (): JSX.Element => {
 
 	const isLoading =
 		dataStatus === DataStatus.IDLE ||
-		(dataStatus === DataStatus.PENDING && hasProject);
+		(dataStatus === DataStatus.PENDING && !hasProject);
 
 	return (
 		<PageLayout>
@@ -131,20 +131,27 @@ const Projects = (): JSX.Element => {
 				<Button label="Create New" onClick={handleCreateModalOpen} />
 			</header>
 			<ProjectsSearch onChange={handleSearchChange} />
-			<div className={styles["projects-list"]}>
-				{isLoading ? (
-					<Loader />
-				) : (
-					projects.map((project) => (
-						<ProjectCard
-							key={project.id}
-							onDelete={handleDeleteClick}
-							onEdit={handleEditClick}
-							project={project}
-						/>
-					))
-				)}
-			</div>
+			{isLoading ? (
+				<Loader />
+			) : (
+				<div className={styles["projects-list"]}>
+					{hasProject ? (
+						projects.map((project) => (
+							<ProjectCard
+								key={project.id}
+								onDelete={handleDeleteClick}
+								onEdit={handleEditClick}
+								project={project}
+							/>
+						))
+					) : (
+						<h1>
+							No projects found matching your search criteria. Please try
+							different keywords.
+						</h1>
+					)}
+				</div>
+			)}
 			<Modal
 				isOpened={isCreateModalOpen}
 				onClose={handleCreateModalClose}

--- a/apps/frontend/src/pages/projects/projects.tsx
+++ b/apps/frontend/src/pages/projects/projects.tsx
@@ -145,10 +145,10 @@ const Projects = (): JSX.Element => {
 							/>
 						))
 					) : (
-						<h1>
+						<p className={styles["no-projects-message"]}>
 							No projects found matching your search criteria. Please try
 							different keywords.
-						</h1>
+						</p>
 					)}
 				</div>
 			)}

--- a/apps/frontend/src/pages/projects/styles.module.css
+++ b/apps/frontend/src/pages/projects/styles.module.css
@@ -17,3 +17,9 @@
 	gap: 12px;
 	padding: 20px 0;
 }
+
+.no-projects-message {
+	font-size: 24px;
+	font-weight: 600;
+	line-height: 100%;
+}


### PR DESCRIPTION
Summary:

- Added the message "No projects found matching your search criteria. Please try different keywords." if no results were found during the search on the "Projects" page.

![image](https://github.com/user-attachments/assets/8370ba03-6ea2-49cb-b65a-3d80d5b051a5)
