### PR TITLE
fix: adjustment of right arrow svg icon to handle custom color attributes gf-208

### DIFF
--- a/apps/frontend/src/assets/images/icons/right-arrow.svg
+++ b/apps/frontend/src/assets/images/icons/right-arrow.svg
@@ -1,3 +1,3 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10.9764 10.0006L6.85156 5.87577L8.03008 4.69727L13.3334 10.0006L8.03008 15.3038L6.85156 14.1253L10.9764 10.0006Z" fill="white"/>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10.9764 10.0006L6.85156 5.87577L8.03008 4.69727L13.3334 10.0006L8.03008 15.3038L6.85156 14.1253L10.9764 10.0006Z" />
 </svg>


### PR DESCRIPTION
Adjuested the SVG color icon  right-arrow.svg to not have fill="white" attribute in it's path, it now handles color values
![ArrowIconColorAdjustment](https://github.com/user-attachments/assets/69e9a177-c897-47c8-ab4e-6a6d0c0dd506)
