### PR TITLE
feat: add display message for empty tables gf-206

### DIFF
--- a/apps/frontend/src/libs/components/table/styles.module.css
+++ b/apps/frontend/src/libs/components/table/styles.module.css
@@ -54,3 +54,12 @@
 .table .table-row:last-child .table-data {
 	border-bottom: none;
 }
+
+.empty-placeholder {
+	margin: 0;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 150%;
+	color: var(--color-text-secondary);
+	text-align: center;
+}

--- a/apps/frontend/src/libs/components/table/table.tsx
+++ b/apps/frontend/src/libs/components/table/table.tsx
@@ -4,6 +4,7 @@ import {
 	useReactTable,
 } from "@tanstack/react-table";
 
+import { EMPTY_LENGTH } from "~/libs/constants/constants.js";
 import { type TableColumn } from "~/libs/types/types.js";
 
 import styles from "./styles.module.css";
@@ -23,6 +24,8 @@ const Table = <T extends object>({
 		getCoreRowModel: getCoreRowModel(),
 	});
 
+	const hasData = data.length !== EMPTY_LENGTH;
+
 	return (
 		<div className={styles["table-container"]}>
 			<table className={styles["table"]}>
@@ -41,15 +44,25 @@ const Table = <T extends object>({
 					))}
 				</thead>
 				<tbody className={styles["table-body"]}>
-					{table.getRowModel().rows.map((row) => (
-						<tr className={styles["table-row"]} key={row.id}>
-							{row.getVisibleCells().map((cell) => (
-								<td className={styles["table-data"]} key={cell.id}>
-									{flexRender(cell.column.columnDef.cell, cell.getContext())}
-								</td>
-							))}
+					{hasData ? (
+						table.getRowModel().rows.map((row) => (
+							<tr className={styles["table-row"]} key={row.id}>
+								{row.getVisibleCells().map((cell) => (
+									<td className={styles["table-data"]} key={cell.id}>
+										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+									</td>
+								))}
+							</tr>
+						))
+					) : (
+						<tr className={styles["table-row"]}>
+							<td className={styles["table-data"]} colSpan={columns.length}>
+								<p className={styles["empty-placeholder"]}>
+									There is nothing yet.
+								</p>
+							</td>
 						</tr>
-					))}
+					)}
 				</tbody>
 			</table>
 		</div>


### PR DESCRIPTION
* Added "There is nothing yet." display message for empty tables.
* Message is added as a single table row in a table with headers.
* Styles are consistent with "No projects found matching your search criteria. Please try different keywords." display message.

![image](https://github.com/user-attachments/assets/8df287cc-bcf7-4a2e-9ef3-d6b2b3721817)