### PR TITLE
fix: fix inconsistent alignment in create group modal gf-265

### DIFF
--- a/apps/frontend/src/libs/components/table/styles.module.css
+++ b/apps/frontend/src/libs/components/table/styles.module.css
@@ -23,13 +23,17 @@
 	border-bottom: 1px solid var(--color-border-primary);
 }
 
+.table .table-header.cell-min-content,
+.table .table-data.cell-min-content {
+	width: 0;
+}
+
 .table .table-data {
 	min-height: 60px;
 	font-weight: 400;
 	line-height: 150%;
 	word-break: break-all;
 	word-wrap: break-word;
-	white-space: normal;
 }
 
 .table .table-header {

--- a/apps/frontend/src/libs/components/table/styles.module.css
+++ b/apps/frontend/src/libs/components/table/styles.module.css
@@ -27,6 +27,9 @@
 	min-height: 60px;
 	font-weight: 400;
 	line-height: 150%;
+	word-break: break-all;
+	word-wrap: break-word;
+	white-space: normal;
 }
 
 .table .table-header {

--- a/apps/frontend/src/libs/components/table/table.tsx
+++ b/apps/frontend/src/libs/components/table/table.tsx
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-table";
 
 import { EMPTY_LENGTH } from "~/libs/constants/constants.js";
+import { getValidClassNames } from "~/libs/helpers/helpers.js";
 import { type TableColumn } from "~/libs/types/types.js";
 
 import { SelectRowCell } from "./libs/components/components.js";
@@ -51,10 +52,10 @@ const Table = <T extends object>({
 						<tr className={styles["table-row"]} key={headerGroup.id}>
 							{isRowSelectable && (
 								<th
-									className={styles["table-header"]}
-									style={{
-										width: 40,
-									}}
+									className={getValidClassNames(
+										styles["table-header"],
+										styles["cell-min-content"],
+									)}
 								/>
 							)}
 							{headerGroup.headers.map((header) => (
@@ -80,10 +81,10 @@ const Table = <T extends object>({
 							<tr className={styles["table-row"]} key={row.id}>
 								{isRowSelectable && (
 									<td
-										className={styles["table-data"]}
-										style={{
-											width: 40,
-										}}
+										className={getValidClassNames(
+											styles["table-data"],
+											styles["cell-min-content"],
+										)}
 									>
 										<SelectRowCell
 											id={getRowId(row.original)}

--- a/apps/frontend/src/libs/components/table/table.tsx
+++ b/apps/frontend/src/libs/components/table/table.tsx
@@ -49,7 +49,14 @@ const Table = <T extends object>({
 				<thead className={styles["table-head"]}>
 					{table.getHeaderGroups().map((headerGroup) => (
 						<tr className={styles["table-row"]} key={headerGroup.id}>
-							{isRowSelectable && <th className={styles["table-header"]} />}
+							{isRowSelectable && (
+								<th
+									className={styles["table-header"]}
+									style={{
+										width: 40,
+									}}
+								/>
+							)}
 							{headerGroup.headers.map((header) => (
 								<th
 									className={styles["table-header"]}
@@ -72,7 +79,12 @@ const Table = <T extends object>({
 						table.getRowModel().rows.map((row) => (
 							<tr className={styles["table-row"]} key={row.id}>
 								{isRowSelectable && (
-									<td className={styles["table-data"]}>
+									<td
+										className={styles["table-data"]}
+										style={{
+											width: 40,
+										}}
+									>
 										<SelectRowCell
 											id={getRowId(row.original)}
 											isChecked={selectedRowIds.includes(

--- a/apps/frontend/src/pages/access-management/libs/components/group-users-table/group-users-table.tsx
+++ b/apps/frontend/src/pages/access-management/libs/components/group-users-table/group-users-table.tsx
@@ -17,8 +17,9 @@ import {
 	type GroupCreateRequestDto,
 } from "~/modules/groups/groups.js";
 
-import { getUserColumns, getUserRows } from "../../helpers/helpers.js";
+import { getUserRows } from "../../helpers/helpers.js";
 import { type UserRow } from "../../types/types.js";
+import { getGroupUsersColumns } from "./libs/helpers/helpers.js";
 import styles from "./styles.module.css";
 
 const getRowId = (row: UserRow): number => row.id;
@@ -47,7 +48,7 @@ const GroupUsersTable = ({
 		totalItemsCount: usersTotalCount,
 	});
 
-	const userColumns = getUserColumns();
+	const userColumns = getGroupUsersColumns();
 	const userData: UserRow[] = getUserRows(users);
 
 	useEffect(() => {
@@ -71,7 +72,7 @@ const GroupUsersTable = ({
 	return (
 		<>
 			<span className={styles["table-title"]}>Users</span>
-			<div className={styles["users-table"]}>
+			<div className={styles["group-users-table"]}>
 				<Table<UserRow>
 					columns={userColumns}
 					data={userData}

--- a/apps/frontend/src/pages/access-management/libs/components/group-users-table/libs/helpers/get-group-users-columns.helper.ts
+++ b/apps/frontend/src/pages/access-management/libs/components/group-users-table/libs/helpers/get-group-users-columns.helper.ts
@@ -1,0 +1,26 @@
+import { formatDate } from "~/libs/helpers/helpers.js";
+import { type TableColumn } from "~/libs/types/types.js";
+import { type UserRow } from "~/pages/access-management/libs/types/types.js";
+
+const getGroupUsersColumns = (): TableColumn<UserRow>[] => {
+	return [
+		{
+			accessorKey: "name",
+			header: "Name",
+			size: 200,
+		},
+		{
+			accessorFn: (user: UserRow): string => user.groups.join(", "),
+			header: "Groups",
+			size: 452,
+		},
+		{
+			accessorFn: (user: UserRow): string =>
+				formatDate(new Date(user.createdAt), "d MMM yyyy HH:mm"),
+			header: "Created At",
+			size: 200,
+		},
+	];
+};
+
+export { getGroupUsersColumns };

--- a/apps/frontend/src/pages/access-management/libs/components/group-users-table/libs/helpers/helpers.ts
+++ b/apps/frontend/src/pages/access-management/libs/components/group-users-table/libs/helpers/helpers.ts
@@ -1,0 +1,1 @@
+export { getGroupUsersColumns } from "./get-group-users-columns.helper.js";

--- a/apps/frontend/src/pages/access-management/libs/components/group-users-table/styles.module.css
+++ b/apps/frontend/src/pages/access-management/libs/components/group-users-table/styles.module.css
@@ -5,6 +5,12 @@
 	line-height: 1.2;
 }
 
+.group-users-table {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
 .error-message {
 	font-size: 14px;
 	font-weight: 500;


### PR DESCRIPTION
* Added gap between table and table pagination.
* Refactored spacing between checkbox and name columns.
* Added word-break and word-wrap to table component to avoid overflow.

![image](https://github.com/user-attachments/assets/cb537652-1669-4fe3-9ece-d69d96f5085a)
