### PR TITLE
fix: Incorrect group positioning in Groups table gf-266

### DIFF
--- a/apps/backend/src/modules/groups/group.repository.ts
+++ b/apps/backend/src/modules/groups/group.repository.ts
@@ -62,6 +62,7 @@ class GroupRepository implements Repository {
 	}: PaginationQueryParameters): Promise<PaginationResponseDto<GroupEntity>> {
 		const { results, total } = await this.groupModel
 			.query()
+			.orderBy("createdAt", "desc")
 			.page(page, pageSize)
 			.withGraphFetched("[permissions, users]");
 


### PR DESCRIPTION
* Groups are ordered from old to new.
* Irrelevant total amount of items bug was fixed before.
![image](https://github.com/user-attachments/assets/d1cebb4a-5de9-4426-ab97-66027d076f31)
(word-break and word-wrap are added in #268)