### PR TITLE
fix: inconsistent layout of the users table gf-267

### DIFF
--- a/apps/frontend/src/pages/access-management/libs/helpers/get-user-columns.helper.ts
+++ b/apps/frontend/src/pages/access-management/libs/helpers/get-user-columns.helper.ts
@@ -8,15 +8,18 @@ const getUserColumns = (): TableColumn<UserRow>[] => {
 		{
 			accessorKey: "name",
 			header: "Name",
+			size: 300,
 		},
 		{
 			accessorFn: (user: UserRow): string => user.groups.join(", "),
 			header: "Groups",
+			size: 500,
 		},
 		{
 			accessorFn: (user: UserRow): string =>
 				formatDate(new Date(user.createdAt), "d MMM yyyy HH:mm"),
 			header: "Created At",
+			size: 200,
 		},
 	];
 };


### PR DESCRIPTION
* Set fixed column sizes in users table according to mockup.
![image](https://github.com/user-attachments/assets/419f2550-9b5a-4e14-85da-8e4a3a056165)
