### PR TITLE
fix: Invalid validation messages in Create group modal gf-262

### DIFF
--- a/packages/shared/src/modules/groups/libs/enums/group-validation-message.enum.ts
+++ b/packages/shared/src/modules/groups/libs/enums/group-validation-message.enum.ts
@@ -1,9 +1,9 @@
 import { GroupValidationRule } from "./group-validation-rule.enum.js";
 
 const GroupValidationMessage = {
-	NAME_REQUIRED: "Project name is required.",
-	NAME_TOO_LONG: `Name is too long (> ${String(GroupValidationRule.NAME_MAXIMUM_LENGTH)} symbols).`,
-	USER_IDS_REQUIRED: "At least one user ID is required.",
+	NAME_REQUIRED: "Group name is required.",
+	NAME_TOO_LONG: `Name cannot be longer than ${String(GroupValidationRule.NAME_MAXIMUM_LENGTH)} characters.`,
+	USER_IDS_REQUIRED: "At least one user is required.",
 } as const;
 
 export { GroupValidationMessage };


### PR DESCRIPTION
* Refactored group validation messages.

![image](https://github.com/user-attachments/assets/19e7bcfa-b2be-4f26-9b24-9cb08befa64f)
![image](https://github.com/user-attachments/assets/6aa393c6-efff-4c0c-aa8b-27c9073cbc9b)
