### PR TITLE
fix: adjusted path for project page breadcrumbs gf-283

### DIFF
--- a/apps/frontend/src/pages/project/project.tsx
+++ b/apps/frontend/src/pages/project/project.tsx
@@ -53,7 +53,7 @@ const Project = (): JSX.Element => {
 					<div className={styles["breadcrumb-container"]}>
 						<Breadcrumbs
 							items={[
-								{ href: AppRoute.ROOT, label: "Projects" },
+								{ href: AppRoute.PROJECTS, label: "Projects" },
 								{ label: project.name },
 							]}
 						/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
 		},
 		"apps/backend": {
 			"name": "@git-fit/backend",
-			"version": "1.10.0",
+			"version": "1.14.0",
 			"dependencies": {
 				"@fastify/static": "7.0.4",
 				"@fastify/swagger": "8.15.0",
@@ -130,7 +130,7 @@
 		},
 		"apps/frontend": {
 			"name": "@git-fit/frontend",
-			"version": "1.15.0",
+			"version": "1.22.0",
 			"dependencies": {
 				"@git-fit/shared": "*",
 				"@hookform/resolvers": "3.9.0",
@@ -13298,7 +13298,7 @@
 		},
 		"packages/shared": {
 			"name": "@git-fit/shared",
-			"version": "1.11.0",
+			"version": "1.15.1",
 			"dependencies": {
 				"change-case": "5.4.4",
 				"date-fns": "3.6.0",


### PR DESCRIPTION
Adjusted the path so it now leads to projects page instead of root 
![project route correction](https://github.com/user-attachments/assets/a28996c2-a491-4ddd-b2fb-d116ac78b6bc)
