### PR TITLE
fix: Group and permission names are broken in the middle of a word gf-299

### DIFF
--- a/apps/frontend/src/libs/components/table/styles.module.css
+++ b/apps/frontend/src/libs/components/table/styles.module.css
@@ -32,7 +32,6 @@
 	min-height: 60px;
 	font-weight: 400;
 	line-height: 150%;
-	word-break: break-all;
 	word-wrap: break-word;
 }
 


### PR DESCRIPTION
* Refactored table styles to break word only if it can't fit in entire line. Before it broke words even if they could fit perfectly on the next line.
## Before
![image](https://github.com/user-attachments/assets/68f63787-b12b-442b-b880-b311cbbce2f8)
## After 
![image](https://github.com/user-attachments/assets/4825db99-0544-4033-b46d-bf7773f60076)
![image](https://github.com/user-attachments/assets/60fd1fe2-d701-4780-97c6-aa503f6cf8f0)
