### PR TITLE
fix: adjusted project status message based on search state gf-313

### DIFF
--- a/apps/frontend/src/pages/projects/projects.tsx
+++ b/apps/frontend/src/pages/projects/projects.tsx
@@ -68,6 +68,10 @@ const Projects = (): JSX.Element => {
 	);
 
 	const hasProject = projects.length !== EMPTY_LENGTH;
+	const hasSearch = search.length !== EMPTY_LENGTH;
+	const ProjectStatusMessage = hasSearch
+		? "No projects found matching your search criteria. Please try different keywords."
+		: "No projects created yet. Create the first project now.";
 
 	const {
 		isOpened: isCreateModalOpen,
@@ -166,8 +170,7 @@ const Projects = (): JSX.Element => {
 						))
 					) : (
 						<p className={styles["empty-placeholder"]}>
-							No projects found matching your search criteria. Please try
-							different keywords.
+							{ProjectStatusMessage}
 						</p>
 					)}
 				</div>

--- a/apps/frontend/src/pages/projects/projects.tsx
+++ b/apps/frontend/src/pages/projects/projects.tsx
@@ -69,7 +69,7 @@ const Projects = (): JSX.Element => {
 
 	const hasProject = projects.length !== EMPTY_LENGTH;
 	const hasSearch = search.length !== EMPTY_LENGTH;
-	const emtyPlaceholderMessage = hasSearch
+	const emptyPlaceholderMessage = hasSearch
 		? "No projects found matching your search criteria. Please try different keywords."
 		: "No projects created yet. Create the first project now.";
 
@@ -170,7 +170,7 @@ const Projects = (): JSX.Element => {
 						))
 					) : (
 						<p className={styles["empty-placeholder"]}>
-							{emtyPlaceholderMessage}
+							{emptyPlaceholderMessage}
 						</p>
 					)}
 				</div>

--- a/apps/frontend/src/pages/projects/projects.tsx
+++ b/apps/frontend/src/pages/projects/projects.tsx
@@ -69,7 +69,7 @@ const Projects = (): JSX.Element => {
 
 	const hasProject = projects.length !== EMPTY_LENGTH;
 	const hasSearch = search.length !== EMPTY_LENGTH;
-	const ProjectStatusMessage = hasSearch
+	const emtyPlaceholderMessage = hasSearch
 		? "No projects found matching your search criteria. Please try different keywords."
 		: "No projects created yet. Create the first project now.";
 
@@ -170,7 +170,7 @@ const Projects = (): JSX.Element => {
 						))
 					) : (
 						<p className={styles["empty-placeholder"]}>
-							{ProjectStatusMessage}
+							{emtyPlaceholderMessage}
 						</p>
 					)}
 				</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 		},
 		"apps/backend": {
 			"name": "@git-fit/backend",
-			"version": "1.14.0",
+			"version": "1.15.0",
 			"dependencies": {
 				"@fastify/static": "7.0.4",
 				"@fastify/swagger": "8.15.0",
@@ -131,7 +131,7 @@
 		},
 		"apps/frontend": {
 			"name": "@git-fit/frontend",
-			"version": "1.22.1",
+			"version": "1.24.0",
 			"dependencies": {
 				"@git-fit/shared": "*",
 				"@hookform/resolvers": "3.9.0",
@@ -13303,7 +13303,7 @@
 		},
 		"packages/shared": {
 			"name": "@git-fit/shared",
-			"version": "1.15.1",
+			"version": "1.16.0",
 			"dependencies": {
 				"change-case": "5.4.4",
 				"date-fns": "3.6.0",
@@ -13317,7 +13317,7 @@
 		},
 		"scripts/analytics": {
 			"name": "@git-fit/analytics",
-			"version": "0.0.0",
+			"version": "1.0.0",
 			"engines": {
 				"node": "20.x.x",
 				"npm": "10.x.x"


### PR DESCRIPTION
 Modified the logic for displaying the project status message to handle two cases:
  - When no projects have been created: "No projects created yet. Create the first project now."
  - When a search query returns no results: "No projects found matching your search criteria. Please try different keywords."
  
 No Projects
![No message](https://github.com/user-attachments/assets/1d1a5a64-439b-439b-aa71-f4c6ddd02566)
No Projects
![No projects](https://github.com/user-attachments/assets/e300ff1d-bdaa-467b-ab59-218c3c84a614)
With projects
![with proj](https://github.com/user-attachments/assets/0b80b400-4322-46b6-b824-bcc5da4181a9)
With Projects
![with proj no search result](https://github.com/user-attachments/assets/63371b09-7db1-4a99-a148-33700b14c3f8)

