### PR TITLE
feat: improve table navigation add a loader to tables gf-311

### DIFF
--- a/apps/frontend/src/pages/access-management/access-management.tsx
+++ b/apps/frontend/src/pages/access-management/access-management.tsx
@@ -172,12 +172,15 @@ const AccessManagement = (): JSX.Element => {
 		}
 	}, [groupDeleteStatus, onDeleteModalClose, handleLoadUsers]);
 
-	const isLoading = [usersDataStatus, groupsDataStatus].some(
-		(status) => status === DataStatus.IDLE || status === DataStatus.PENDING,
-	);
+	const isLoadingUsersData =
+		usersDataStatus === DataStatus.IDLE ||
+		usersDataStatus === DataStatus.PENDING;
+	const isLoadingGroupsData =
+		groupsDataStatus === DataStatus.IDLE ||
+		groupsDataStatus === DataStatus.PENDING;
 
 	return (
-		<PageLayout isLoading={isLoading}>
+		<PageLayout>
 			<h1 className={styles["title"]}>Access Management</h1>
 
 			<section>
@@ -185,6 +188,7 @@ const AccessManagement = (): JSX.Element => {
 					<h2 className={styles["section-title"]}>Users</h2>
 				</div>
 				<UsersTable
+					isloading={isLoadingUsersData}
 					onPageChange={onUserPageChange}
 					onPageSizeChange={onUserPageSizeChange}
 					page={userPage}
@@ -204,6 +208,7 @@ const AccessManagement = (): JSX.Element => {
 
 				<GroupsTable
 					groups={groups}
+					isloading={isLoadingGroupsData}
 					onDelete={handleDelete}
 					onEdit={handleEdit}
 					onPageChange={onGroupPageChange}

--- a/apps/frontend/src/pages/access-management/libs/components/groups-table/groups-table.tsx
+++ b/apps/frontend/src/pages/access-management/libs/components/groups-table/groups-table.tsx
@@ -7,6 +7,7 @@ import styles from "./styles.module.css";
 
 type Properties = {
 	groups: GroupGetAllItemResponseDto[];
+	isloading: boolean;
 	onDelete: (id: number) => void;
 	onEdit: (group: GroupGetAllItemResponseDto) => void;
 	onPageChange: (page: number) => void;
@@ -19,6 +20,7 @@ type Properties = {
 
 const GroupsTable = ({
 	groups,
+	isloading,
 	onDelete,
 	onEdit,
 	onPageChange,
@@ -41,7 +43,11 @@ const GroupsTable = ({
 
 	return (
 		<div className={styles["groups-table"]}>
-			<Table<GroupRow> columns={groupColumns} data={groupData} />
+			<Table<GroupRow>
+				columns={groupColumns}
+				data={groupData}
+				isLoading={isloading}
+			/>
 			<TablePagination
 				background={paginationBackground}
 				onPageChange={onPageChange}

--- a/apps/frontend/src/pages/access-management/libs/components/users-table/users-table.tsx
+++ b/apps/frontend/src/pages/access-management/libs/components/users-table/users-table.tsx
@@ -6,6 +6,7 @@ import { type UserRow } from "../../types/types.js";
 import styles from "./styles.module.css";
 
 type Properties = {
+	isloading: boolean;
 	onPageChange: (page: number) => void;
 	onPageSizeChange: (pageSize: number) => void;
 	page: number;
@@ -16,6 +17,7 @@ type Properties = {
 };
 
 const UsersTable = ({
+	isloading,
 	onPageChange,
 	onPageSizeChange,
 	page,
@@ -29,7 +31,11 @@ const UsersTable = ({
 
 	return (
 		<div className={styles["users-table"]}>
-			<Table<UserRow> columns={userColumns} data={userData} />
+			<Table<UserRow>
+				columns={userColumns}
+				data={userData}
+				isLoading={isloading}
+			/>
 			<TablePagination
 				background={paginationBackground}
 				onPageChange={onPageChange}


### PR DESCRIPTION
The page does not scroll up while navigating the Users and Groups tables.
A loader is displayed within the table to indicate loading.