### PR TITLE
fix: restrict users to manage projects gf-324

### DIFF
--- a/apps/backend/src/modules/projects/project.controller.ts
+++ b/apps/backend/src/modules/projects/project.controller.ts
@@ -61,6 +61,7 @@ class ProjectController extends BaseController {
 				),
 			method: "POST",
 			path: ProjectsApiPath.ROOT,
+			preHandlers: [checkUserPermissions([PermissionKey.VIEW_ALL_PROJECTS])],
 			validation: {
 				body: projectCreateValidationSchema,
 			},
@@ -75,6 +76,7 @@ class ProjectController extends BaseController {
 				),
 			method: "DELETE",
 			path: ProjectsApiPath.$ID,
+			preHandlers: [checkUserPermissions([PermissionKey.VIEW_ALL_PROJECTS])],
 		});
 
 		this.addRoute({
@@ -111,6 +113,7 @@ class ProjectController extends BaseController {
 				),
 			method: "PATCH",
 			path: ProjectsApiPath.$ID,
+			preHandlers: [checkUserPermissions([PermissionKey.VIEW_ALL_PROJECTS])],
 			validation: {
 				body: projectPatchValidationSchema,
 			},


### PR DESCRIPTION
Restrict users from creating/editing/deleting groups on the backend.
![image](https://github.com/user-attachments/assets/86732840-245c-44fa-8689-1ffe1b280226)
