### PR TITLE
fix: groups table refresh on deletion of group gf-329

### DIFF
--- a/apps/frontend/src/pages/access-management/access-management.tsx
+++ b/apps/frontend/src/pages/access-management/access-management.tsx
@@ -167,10 +167,16 @@ const AccessManagement = (): JSX.Element => {
 	useEffect(() => {
 		if (groupDeleteStatus === DataStatus.FULFILLED) {
 			handleLoadUsers();
+			handleLoadGroups();
 			onDeleteModalClose();
 			setGroupToDeleteId(null);
 		}
-	}, [groupDeleteStatus, onDeleteModalClose, handleLoadUsers]);
+	}, [
+		groupDeleteStatus,
+		onDeleteModalClose,
+		handleLoadUsers,
+		handleLoadGroups,
+	]);
 
 	const isLoading = [usersDataStatus, groupsDataStatus].some(
 		(status) => status === DataStatus.IDLE || status === DataStatus.PENDING,

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 		},
 		"apps/backend": {
 			"name": "@git-fit/backend",
-			"version": "1.16.0",
+			"version": "1.17.0",
 			"dependencies": {
 				"@fastify/static": "7.0.4",
 				"@fastify/swagger": "8.15.0",
@@ -132,7 +132,7 @@
 		},
 		"apps/frontend": {
 			"name": "@git-fit/frontend",
-			"version": "1.25.0",
+			"version": "1.26.1",
 			"dependencies": {
 				"@git-fit/shared": "*",
 				"@hookform/resolvers": "3.9.0",

--- a/packages/shared/src/modules/projects/libs/types/project-get-all-request-dto.type.ts
+++ b/packages/shared/src/modules/projects/libs/types/project-get-all-request-dto.type.ts
@@ -1,4 +1,4 @@
-import { type PaginationQueryParameters } from "src/libs/types/types.js";
+import { type PaginationQueryParameters } from "../../../../libs/types/types.js";
 
 type ProjectGetAllRequestDto = {
 	name: string;


### PR DESCRIPTION
Updated group deletion logic to automatically refresh the table after deleting a group.
Made sure that pagination is working properly on deletion.

Table refreshing on delete

https://github.com/user-attachments/assets/22fef328-2d10-4c63-9889-0f3bcbf090ae

table changing page on delete


https://github.com/user-attachments/assets/e9b2ca33-34ac-43c9-8c9e-700322c05997



