### PR TITLE
feat: add project last activity label to project list gf-274

### DIFF
--- a/apps/backend/src/db/migrations/20240916154357_add_last_activity_date_to_projects_table.ts
+++ b/apps/backend/src/db/migrations/20240916154357_add_last_activity_date_to_projects_table.ts
@@ -1,0 +1,21 @@
+import { type Knex } from "knex";
+
+const TABLE_NAME = "projects";
+
+const ColumnName = {
+	LAST_ACTIVITY_DATE: "last_activity_date",
+} as const;
+
+function up(knex: Knex): Promise<void> {
+	return knex.schema.alterTable(TABLE_NAME, (table) => {
+		table.dateTime(ColumnName.LAST_ACTIVITY_DATE).nullable();
+	});
+}
+
+function down(knex: Knex): Promise<void> {
+	return knex.schema.alterTable(TABLE_NAME, (table) => {
+		table.dropColumn(ColumnName.LAST_ACTIVITY_DATE);
+	});
+}
+
+export { down, up };

--- a/apps/backend/src/modules/activity-logs/activity-log.service.ts
+++ b/apps/backend/src/modules/activity-logs/activity-log.service.ts
@@ -2,6 +2,7 @@ import { type Service } from "~/libs/types/types.js";
 import { type ContributorService } from "~/modules/contributors/contributors.js";
 import { type GitEmailService } from "~/modules/git-emails/git-emails.js";
 import { type ProjectApiKeyService } from "~/modules/project-api-keys/project-api-keys.js";
+import { type ProjectService } from "~/modules/projects/project.service.js";
 
 import { ActivityLogEntity } from "./activity-log.entity.js";
 import { type ActivityLogRepository } from "./activity-log.repository.js";
@@ -16,6 +17,7 @@ type Constructor = {
 	contributorService: ContributorService;
 	gitEmailService: GitEmailService;
 	projectApiKeyService: ProjectApiKeyService;
+	projectService: ProjectService;
 };
 
 class ActivityLogService implements Service {
@@ -23,17 +25,20 @@ class ActivityLogService implements Service {
 	private contributorService: ContributorService;
 	private gitEmailService: GitEmailService;
 	private projectApiKeyService: ProjectApiKeyService;
+	private projectService: ProjectService;
 
 	public constructor({
 		activityLogRepository,
 		contributorService,
 		gitEmailService,
 		projectApiKeyService,
+		projectService,
 	}: Constructor) {
 		this.activityLogRepository = activityLogRepository;
 		this.contributorService = contributorService;
 		this.gitEmailService = gitEmailService;
 		this.projectApiKeyService = projectApiKeyService;
+		this.projectService = projectService;
 	}
 
 	private async createActivityLog({
@@ -56,6 +61,8 @@ class ActivityLogService implements Service {
 				email: authorEmail,
 			});
 		}
+
+		await this.projectService.updateLastActivityDate(projectId, date);
 
 		return await this.activityLogRepository.create(
 			ActivityLogEntity.initializeNew({

--- a/apps/backend/src/modules/activity-logs/activity-logs.ts
+++ b/apps/backend/src/modules/activity-logs/activity-logs.ts
@@ -2,11 +2,20 @@ import { logger } from "~/libs/modules/logger/logger.js";
 import { contributorService } from "~/modules/contributors/contributors.js";
 import { gitEmailService } from "~/modules/git-emails/git-emails.js";
 import { projectApiKeyService } from "~/modules/project-api-keys/project-api-keys.js";
+import { ProjectModel } from "~/modules/projects/project.model.js";
+import { ProjectRepository } from "~/modules/projects/project.repository.js";
+import { ProjectService } from "~/modules/projects/project.service.js";
 
 import { ActivityLogController } from "./activity-log.controller.js";
 import { ActivityLogModel } from "./activity-log.model.js";
 import { ActivityLogRepository } from "./activity-log.repository.js";
 import { ActivityLogService } from "./activity-log.service.js";
+
+const projectRepository = new ProjectRepository(ProjectModel);
+const projectService = new ProjectService(
+	projectRepository,
+	projectApiKeyService,
+);
 
 const activityLogRepository = new ActivityLogRepository(ActivityLogModel);
 const activityLogService = new ActivityLogService({
@@ -14,6 +23,7 @@ const activityLogService = new ActivityLogService({
 	contributorService,
 	gitEmailService,
 	projectApiKeyService,
+	projectService,
 });
 const activityLogController = new ActivityLogController(
 	logger,

--- a/apps/backend/src/modules/projects/project.entity.ts
+++ b/apps/backend/src/modules/projects/project.entity.ts
@@ -7,34 +7,42 @@ class ProjectEntity implements Entity {
 
 	private id: null | number;
 
+	private lastActivityDate!: null | string;
+
 	private name!: string;
 
 	private constructor({
 		description,
 		id,
+		lastActivityDate,
 		name,
 	}: {
 		description: string;
 		id: null | number;
+		lastActivityDate: null | string;
 		name: string;
 	}) {
 		this.id = id;
 		this.description = description;
+		this.lastActivityDate = lastActivityDate;
 		this.name = name;
 	}
 
 	public static initialize({
 		description,
 		id,
+		lastActivityDate,
 		name,
 	}: {
 		description: string;
 		id: number;
+		lastActivityDate: string;
 		name: string;
 	}): ProjectEntity {
 		return new ProjectEntity({
 			description,
 			id,
+			lastActivityDate,
 			name,
 		});
 	}
@@ -49,6 +57,7 @@ class ProjectEntity implements Entity {
 		return new ProjectEntity({
 			description,
 			id: null,
+			lastActivityDate: null,
 			name,
 		});
 	}
@@ -65,11 +74,12 @@ class ProjectEntity implements Entity {
 
 	public toObject(): Pick<
 		ProjectGetByIdResponseDto,
-		"description" | "id" | "name"
+		"description" | "id" | "lastActivityDate" | "name"
 	> {
 		return {
 			description: this.description,
 			id: this.id as number,
+			lastActivityDate: this.lastActivityDate,
 			name: this.name,
 		};
 	}

--- a/apps/backend/src/modules/projects/project.model.ts
+++ b/apps/backend/src/modules/projects/project.model.ts
@@ -6,6 +6,8 @@ import {
 class ProjectModel extends AbstractModel {
 	public description!: string;
 
+	public lastActivityDate!: string;
+
 	public name!: string;
 
 	public static override get tableName(): string {

--- a/apps/backend/src/modules/projects/project.repository.ts
+++ b/apps/backend/src/modules/projects/project.repository.ts
@@ -80,6 +80,17 @@ class ProjectRepository implements Repository {
 	public update(): ReturnType<Repository["update"]> {
 		return Promise.resolve(null);
 	}
+
+	public async updateLastActivityDate(
+		projectId: number,
+		lastActivityDate: string,
+	): Promise<void> {
+		await this.projectModel
+			.query()
+			.patch({ lastActivityDate })
+			.where({ id: projectId })
+			.execute();
+	}
 }
 
 export { ProjectRepository };

--- a/apps/backend/src/modules/projects/project.service.ts
+++ b/apps/backend/src/modules/projects/project.service.ts
@@ -93,9 +93,9 @@ class ProjectService implements Service {
 
 		return {
 			items: projects.items.map((item) => {
-				const { id, name } = item.toObject();
+				const { id, lastActivityDate, name } = item.toObject();
 
-				return { id, name };
+				return { id, lastActivityDate, name };
 			}),
 		};
 	}
@@ -142,6 +142,16 @@ class ProjectService implements Service {
 
 	public update(): ReturnType<Service["update"]> {
 		return Promise.resolve(null);
+	}
+
+	public async updateLastActivityDate(
+		projectId: number,
+		lastActivityDate: string,
+	): Promise<void> {
+		await this.projectRepository.updateLastActivityDate(
+			projectId,
+			lastActivityDate,
+		);
 	}
 }
 

--- a/apps/frontend/src/pages/projects/libs/components/project-card/project-card.tsx
+++ b/apps/frontend/src/pages/projects/libs/components/project-card/project-card.tsx
@@ -1,10 +1,11 @@
 import { NavLink } from "react-router-dom";
 
 import { AppRoute } from "~/libs/enums/enums.js";
-import { configureString } from "~/libs/helpers/helpers.js";
+import { configureString, getValidClassNames } from "~/libs/helpers/helpers.js";
 import { useCallback } from "~/libs/hooks/hooks.js";
 import { type ProjectGetAllItemResponseDto } from "~/modules/projects/projects.js";
 
+import { getRelativeDateLabel } from "../../helpers/helpers.js";
 import { ProjectMenu } from "../components.js";
 import styles from "./styles.module.css";
 
@@ -31,11 +32,25 @@ const ProjectCard = ({
 		onDelete(project);
 	}, [onDelete, project]);
 
+	const lastUpdate = getRelativeDateLabel(project.lastActivityDate);
+
 	return (
 		<div className={styles["project-container"]}>
 			<NavLink className={styles["project"] as string} to={projectRoute}>
 				{project.name}
 			</NavLink>
+			{lastUpdate && (
+				<div className={styles["last-activity-wrapper"]}>
+					<span
+						className={getValidClassNames(
+							styles["last-activity"],
+							styles[lastUpdate.colorClass],
+						)}
+					>
+						{lastUpdate.label}
+					</span>
+				</div>
+			)}
 			<ProjectMenu onDelete={handleDeleteClick} onEdit={handleEditClick} />
 		</div>
 	);

--- a/apps/frontend/src/pages/projects/libs/components/project-card/styles.module.css
+++ b/apps/frontend/src/pages/projects/libs/components/project-card/styles.module.css
@@ -25,3 +25,35 @@
 	text-decoration: none;
 	background: transparent;
 }
+
+.last-activity-wrapper {
+	width: 100%;
+	padding: 0 33%;
+}
+
+.last-activity {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+}
+
+.last-activity::before {
+	display: inline-block;
+	width: 12px;
+	height: 12px;
+	margin-right: 8px;
+	content: "";
+	border-radius: 50%;
+}
+
+.green::before {
+	background-color: var(--color-success);
+}
+
+.yellow::before {
+	background-color: var(--color-warning);
+}
+
+.red::before {
+	background-color: var(--color-danger);
+}

--- a/apps/frontend/src/pages/projects/libs/enums/color-class.enum.ts
+++ b/apps/frontend/src/pages/projects/libs/enums/color-class.enum.ts
@@ -1,0 +1,7 @@
+const ColorClass = {
+	GREEN: "green",
+	RED: "red",
+	YELLOW: "yellow",
+} as const;
+
+export { ColorClass };

--- a/apps/frontend/src/pages/projects/libs/enums/color-threshold.enum.ts
+++ b/apps/frontend/src/pages/projects/libs/enums/color-threshold.enum.ts
@@ -1,0 +1,6 @@
+const ColorThreshold = {
+	GREEN: 2,
+	YELLOW: 5,
+} as const;
+
+export { ColorThreshold };

--- a/apps/frontend/src/pages/projects/libs/enums/enums.ts
+++ b/apps/frontend/src/pages/projects/libs/enums/enums.ts
@@ -1,0 +1,2 @@
+export { ColorClass } from "./color-class.enum.js";
+export { ColorThreshold } from "./color-threshold.enum.js";

--- a/apps/frontend/src/pages/projects/libs/helpers/get-relative-date-label.helper.tsx
+++ b/apps/frontend/src/pages/projects/libs/helpers/get-relative-date-label.helper.tsx
@@ -1,0 +1,38 @@
+import { getDifferenceInDays } from "~/libs/helpers/helpers.js";
+
+import { ColorClass, ColorThreshold } from "../enums/enums.js";
+
+type RelativeDateLabel = {
+	colorClass: string;
+	label: string;
+} | null;
+
+const getRelativeDateLabel = (
+	lastActivityDate: null | string,
+): RelativeDateLabel => {
+	if (!lastActivityDate) {
+		return null;
+	}
+
+	const currentDate = new Date();
+	const lastActivity = new Date(lastActivityDate);
+	const diffDays = getDifferenceInDays(currentDate, lastActivity);
+
+	if (diffDays < ColorThreshold.GREEN) {
+		return { colorClass: ColorClass.GREEN, label: "Updated today" };
+	}
+
+	if (diffDays < ColorThreshold.YELLOW) {
+		return {
+			colorClass: ColorClass.YELLOW,
+			label: `Updated ${diffDays.toString()} days ago`,
+		};
+	}
+
+	return {
+		colorClass: ColorClass.RED,
+		label: `Updated ${diffDays.toString()} days ago`,
+	};
+};
+
+export { getRelativeDateLabel };

--- a/apps/frontend/src/pages/projects/libs/helpers/helpers.ts
+++ b/apps/frontend/src/pages/projects/libs/helpers/helpers.ts
@@ -1,0 +1,1 @@
+export { getRelativeDateLabel } from "./get-relative-date-label.helper.js";

--- a/packages/shared/src/modules/projects/libs/types/project-get-all-item-response-dto.type.ts
+++ b/packages/shared/src/modules/projects/libs/types/project-get-all-item-response-dto.type.ts
@@ -1,5 +1,6 @@
 type ProjectGetAllItemResponseDto = {
 	id: number;
+	lastActivityDate: null | string;
 	name: string;
 };
 

--- a/packages/shared/src/modules/projects/libs/types/project-get-by-id-response-dto.type.ts
+++ b/packages/shared/src/modules/projects/libs/types/project-get-by-id-response-dto.type.ts
@@ -2,6 +2,7 @@ type ProjectGetByIdResponseDto = {
 	apiKey: null | string;
 	description: string;
 	id: number;
+	lastActivityDate: null | string;
 	name: string;
 };
 

--- a/packages/shared/src/modules/projects/libs/types/project-patch-response-dto.type.ts
+++ b/packages/shared/src/modules/projects/libs/types/project-patch-response-dto.type.ts
@@ -2,6 +2,7 @@ type ProjectPatchResponseDto = {
 	apiKey: null | string;
 	description: string;
 	id: number;
+	lastActivityDate: null | string;
 	name: string;
 };
 


### PR DESCRIPTION
- added a Migration: add `last_activity_date` to the projects table, defaulting to null;
- updated Projects module: add new property lastActivityDate and update method updateLastActivityDate;
- updated Activity Logs module: update last_activity_date when creating activity logs;
- adjust frontend: add 'last activity' label with appropriate color indicators based on last_activity_date.