### PR TITLE
fix: the last month in the calendar component on the analytics page is shown with empty data gf-357

### DIFF
--- a/apps/frontend/src/libs/components/date-input/styles.module.css
+++ b/apps/frontend/src/libs/components/date-input/styles.module.css
@@ -103,7 +103,7 @@
 .calendar :global(.react-calendar__year-view__months),
 .calendar :global(.react-calendar__decade-view__years),
 .calendar :global(.react-calendar__century-view__decades) {
-	max-width: 128px;
+	min-width: 128px;
 }
 
 .date-input-trigger {

--- a/apps/frontend/src/libs/components/date-input/styles.module.css
+++ b/apps/frontend/src/libs/components/date-input/styles.module.css
@@ -45,16 +45,12 @@
 	border: none;
 }
 
-.calendar :global(.react-calendar__tile:disabled) {
-	color: transparent;
-	background-color: transparent;
-}
-
 .calendar :global(.react-calendar__tile:enabled:hover) {
 	background-color: var(--color-background-hover);
 }
 
-.calendar :global(.react-calendar__month-view__days__day--neighboringMonth) {
+.calendar :global(.react-calendar__month-view__days__day--neighboringMonth),
+.calendar :global(.react-calendar__tile:disabled) {
 	opacity: 0.5;
 }
 


### PR DESCRIPTION
Made future days visible with color of neighboring month. (They are disabled as well, user can not choose them). Also noticed a problem with bigger scale views and fixed it. (Looks like it came up after changes that were made now).

<img width="506" alt="Screenshot 2024-09-17 at 12 33 56" src="https://github.com/user-attachments/assets/1a0357dc-65d8-41a6-b47c-6def503608c4">
