### PR TITLE
fix: implemented emtyplaceholdermessage to handle statusmessage for projects page gf-313

### DIFF
--- a/apps/frontend/src/pages/projects/projects.tsx
+++ b/apps/frontend/src/pages/projects/projects.tsx
@@ -67,6 +67,10 @@ const Projects = (): JSX.Element => {
 	}, [dispatch, projectToModifyId]);
 
 	const hasProjects = projects.length !== EMPTY_LENGTH;
+	const hasSearch = search.length !== EMPTY_LENGTH;
+	const emptyPlaceholderMessage = hasSearch
+		? "No projects found matching your search criteria. Please try different keywords."
+		: "No projects created yet. Create the first project now.";
 
 	const handleLoadProjects = useCallback(
 		(page: number, pageSize: number) => {
@@ -200,8 +204,7 @@ const Projects = (): JSX.Element => {
 						))
 					) : (
 						<p className={styles["empty-placeholder"]}>
-							No projects found matching your search criteria. Please try
-							different keywords.
+							{emptyPlaceholderMessage}
 						</p>
 					)}
 


### PR DESCRIPTION
Implemented the emtyPlaceHolderMessage to handle the status message for projects, to fix the status message
Now it shows correctly each statement depending on search or no projects
![new pr no proj](https://github.com/user-attachments/assets/e2828e51-7119-4b5c-8116-872cc4eef188)

![New pr no search](https://github.com/user-attachments/assets/a9af5bdd-a721-478c-870e-ae4d0efbfe28)
