### PR TITLE
fix: improve error handling in creating activity logs gf-332

### DIFF
--- a/apps/backend/src/modules/activity-logs/activity-log.service.ts
+++ b/apps/backend/src/modules/activity-logs/activity-log.service.ts
@@ -73,7 +73,7 @@ class ActivityLogService implements Service {
 		} catch {
 			throw new ActivityLogError({
 				message: ExceptionMessage.ACTIVITY_LOG_CREATE_FAILED,
-				status: HTTPCode.INTERNAL_SERVER_ERROR,
+				status: HTTPCode.FORBIDDEN,
 			});
 		}
 	}

--- a/apps/backend/src/modules/activity-logs/activity-log.service.ts
+++ b/apps/backend/src/modules/activity-logs/activity-log.service.ts
@@ -1,3 +1,5 @@
+import { ExceptionMessage } from "~/libs/enums/enums.js";
+import { HTTPCode } from "~/libs/modules/http/http.js";
 import { type Service } from "~/libs/types/types.js";
 import { type ContributorService } from "~/modules/contributors/contributors.js";
 import { type GitEmailService } from "~/modules/git-emails/git-emails.js";
@@ -5,6 +7,7 @@ import { type ProjectApiKeyService } from "~/modules/project-api-keys/project-ap
 
 import { ActivityLogEntity } from "./activity-log.entity.js";
 import { type ActivityLogRepository } from "./activity-log.repository.js";
+import { ActivityLogError } from "./libs/exceptions/exceptions.js";
 import {
 	type ActivityLogCreateItemResponseDto,
 	type ActivityLogCreateRequestDto,
@@ -57,15 +60,22 @@ class ActivityLogService implements Service {
 			});
 		}
 
-		return await this.activityLogRepository.create(
-			ActivityLogEntity.initializeNew({
-				commitsNumber,
-				createdByUser: { id: userId },
-				date,
-				gitEmail: { contributor: gitEmail.contributor, id: gitEmail.id },
-				project: { id: projectId },
-			}),
-		);
+		try {
+			return await this.activityLogRepository.create(
+				ActivityLogEntity.initializeNew({
+					commitsNumber,
+					createdByUser: { id: userId },
+					date,
+					gitEmail: { contributor: gitEmail.contributor, id: gitEmail.id },
+					project: { id: projectId },
+				}),
+			);
+		} catch {
+			throw new ActivityLogError({
+				message: ExceptionMessage.ACTIVITY_LOG_CREATE_FAILED,
+				status: HTTPCode.INTERNAL_SERVER_ERROR,
+			});
+		}
 	}
 
 	public async create(

--- a/apps/backend/src/modules/activity-logs/libs/exceptions/exceptions.ts
+++ b/apps/backend/src/modules/activity-logs/libs/exceptions/exceptions.ts
@@ -1,0 +1,1 @@
+export { ActivityLogError } from "@git-fit/shared";

--- a/packages/shared/src/libs/enums/exception-message.enum.ts
+++ b/packages/shared/src/libs/enums/exception-message.enum.ts
@@ -1,4 +1,5 @@
 const ExceptionMessage = {
+	ACTIVITY_LOG_CREATE_FAILED: "Failed to create activity log.",
 	CONTRIBUTOR_NOT_FOUND: "Contributor not found.",
 	EMAIL_USED: "Email address is already in use.",
 	GIT_EMAIL_USED: "Git email is already in use.",

--- a/packages/shared/src/modules/activity-logs/libs/enums/activity-log-validation-message.enum.ts
+++ b/packages/shared/src/modules/activity-logs/libs/enums/activity-log-validation-message.enum.ts
@@ -5,6 +5,7 @@ const ActivityLogValidationMessage = {
 	COMMITS_NUMBER_REQUIRED: "Commits number is required.",
 	DATE_REQUIRED: "Date is required.",
 	ITEMS_REQUIRED: "Activity log items cannot be empty.",
+	USER_ID_REQUIRED: "User id is required.",
 } as const;
 
 export { ActivityLogValidationMessage };

--- a/packages/shared/src/modules/activity-logs/libs/validation-schemas/activity-log-create.validation-schema.ts
+++ b/packages/shared/src/modules/activity-logs/libs/validation-schemas/activity-log-create.validation-schema.ts
@@ -37,5 +37,11 @@ const activityLogCreate = z.object({
 	items: z
 		.array(activityLogItemCreate)
 		.nonempty(ActivityLogValidationMessage.ITEMS_REQUIRED),
+	userId: z
+		.number({
+			required_error: ActivityLogValidationMessage.USER_ID_REQUIRED,
+		})
+		.int()
+		.positive(),
 });
 export { activityLogCreate };


### PR DESCRIPTION
The "Failed to create activity log." error was added if the creation of new log goes wrong. Also the validation schema was fixed.

Earlier:
![image](https://github.com/user-attachments/assets/e037f6bd-7230-4bb3-968d-51a1b0d1aebb)

Now:
![image](https://github.com/user-attachments/assets/d165fc8a-2ea7-47ca-b4af-93633b669289)
