### PR TITLE
fix: Make project group name unique only within the scope of a project gf-361

### DIFF
--- a/apps/backend/src/modules/project-groups/libs/helpers/generate-project-group-key.helper.ts
+++ b/apps/backend/src/modules/project-groups/libs/helpers/generate-project-group-key.helper.ts
@@ -1,0 +1,15 @@
+import { changeCase } from "~/libs/helpers/helpers.js";
+
+const generateProjectGroupKey = ({
+	name,
+	projectId,
+}: {
+	name: string;
+	projectId: number;
+}): string => {
+	const key = [projectId, name].join(" ");
+
+	return changeCase(key, "snakeCase");
+};
+
+export { generateProjectGroupKey };

--- a/apps/backend/src/modules/project-groups/libs/helpers/helpers.ts
+++ b/apps/backend/src/modules/project-groups/libs/helpers/helpers.ts
@@ -1,0 +1,1 @@
+export { generateProjectGroupKey } from "./generate-project-group-key.helper.js";

--- a/apps/backend/src/modules/project-groups/project-group.repository.ts
+++ b/apps/backend/src/modules/project-groups/project-group.repository.ts
@@ -1,7 +1,6 @@
 import { transaction } from "objection";
 
 import { SortType } from "~/libs/enums/enums.js";
-import { changeCase } from "~/libs/helpers/helpers.js";
 import { HTTPCode } from "~/libs/modules/http/libs/enums/enums.js";
 import {
 	type PaginationQueryParameters,
@@ -11,6 +10,7 @@ import {
 
 import { ExceptionMessage } from "./libs/enums/enums.js";
 import { ProjectGroupError } from "./libs/exceptions/exceptions.js";
+import { generateProjectGroupKey } from "./libs/helpers/helpers.js";
 import { ProjectGroupEntity } from "./project-group.entity.js";
 import { type ProjectGroupModel } from "./project-group.model.js";
 
@@ -23,7 +23,10 @@ class ProjectGroupRepository implements Repository {
 
 	public async create(entity: ProjectGroupEntity): Promise<ProjectGroupEntity> {
 		const { name, permissions, projectId, users } = entity.toNewObject();
-		const key = changeCase([String(projectId.id), name], "snakeCase");
+		const key = generateProjectGroupKey({
+			name,
+			projectId: projectId.id,
+		});
 
 		const trx = await transaction.start(this.projectGroupModel.knex());
 
@@ -105,7 +108,10 @@ class ProjectGroupRepository implements Repository {
 		name: string;
 		projectId: number;
 	}): Promise<null | ProjectGroupModel> {
-		const key = changeCase([String(projectId), name], "snakeCase");
+		const key = generateProjectGroupKey({
+			name,
+			projectId,
+		});
 
 		return (
 			(await this.projectGroupModel

--- a/apps/backend/src/modules/project-groups/project-group.repository.ts
+++ b/apps/backend/src/modules/project-groups/project-group.repository.ts
@@ -142,7 +142,10 @@ class ProjectGroupRepository implements Repository {
 		entity: ProjectGroupEntity,
 	): Promise<ProjectGroupEntity> {
 		const { name, permissions, projectId, users } = entity.toNewObject();
-		const key = changeCase(name, "snakeCase");
+		const key = generateProjectGroupKey({
+			name,
+			projectId: projectId.id,
+		});
 
 		const trx = await transaction.start(this.projectGroupModel.knex());
 

--- a/apps/backend/src/modules/project-groups/project-group.service.ts
+++ b/apps/backend/src/modules/project-groups/project-group.service.ts
@@ -27,7 +27,10 @@ class ProjectGroupService implements Service {
 		const { name, permissionIds = [], projectId, userIds } = payload;
 
 		const existingProjectGroup =
-			await this.projectGroupRepository.findByName(name);
+			await this.projectGroupRepository.findByProjectIdAndName({
+				name,
+				projectId,
+			});
 
 		if (existingProjectGroup) {
 			throw new ProjectGroupError({

--- a/apps/backend/src/modules/project-groups/project-group.service.ts
+++ b/apps/backend/src/modules/project-groups/project-group.service.ts
@@ -114,7 +114,10 @@ class ProjectGroupService implements Service {
 		const { name, permissionIds = [], userIds } = payload;
 
 		const existingProjectGroup =
-			await this.projectGroupRepository.findByName(name);
+			await this.projectGroupRepository.findByProjectIdAndName({
+				name,
+				projectId,
+			});
 
 		if (existingProjectGroup && existingProjectGroup.id !== id) {
 			throw new ProjectGroupError({

--- a/packages/shared/src/libs/helpers/change-case/change-case.helper.ts
+++ b/packages/shared/src/libs/helpers/change-case/change-case.helper.ts
@@ -1,10 +1,14 @@
 import { caseTypeToFunction } from "./libs/maps/maps.js";
 import { type CaseType } from "./libs/types/types.js";
 
-const changeCase = (input: string, caseType: CaseType): string => {
+const changeCase = (
+	input: Array<string> | string,
+	caseType: CaseType,
+): string => {
 	const caseFunction = caseTypeToFunction[caseType];
+	const parsedInput = Array.isArray(input) ? input.join(" ") : input;
 
-	return caseFunction(input);
+	return caseFunction(parsedInput);
 };
 
 export { changeCase };

--- a/packages/shared/src/libs/helpers/change-case/change-case.helper.ts
+++ b/packages/shared/src/libs/helpers/change-case/change-case.helper.ts
@@ -1,14 +1,10 @@
 import { caseTypeToFunction } from "./libs/maps/maps.js";
 import { type CaseType } from "./libs/types/types.js";
 
-const changeCase = (
-	input: Array<string> | string,
-	caseType: CaseType,
-): string => {
+const changeCase = (input: string, caseType: CaseType): string => {
 	const caseFunction = caseTypeToFunction[caseType];
-	const parsedInput = Array.isArray(input) ? input.join(" ") : input;
 
-	return caseFunction(parsedInput);
+	return caseFunction(input);
 };
 
 export { changeCase };


### PR DESCRIPTION
- unique project group key is fixed by adding project id
- changed checking of existing group