### PR TITLE
feat: added placeholder to contributors list on project page gf-377

### DIFF
--- a/apps/frontend/src/pages/project/libs/components/contributors-list/contributors-list.tsx
+++ b/apps/frontend/src/pages/project/libs/components/contributors-list/contributors-list.tsx
@@ -15,12 +15,14 @@ const ContributorsList = ({
 	isLoading,
 }: Properties): JSX.Element => {
 	const hasContributors = contributors.length > EMPTY_LENGTH;
+	const isListShown = !isLoading && hasContributors;
+	const isEmptyPlaceholderShown = !isLoading && !hasContributors;
 
 	return (
 		<div className={styles["container"]}>
 			<h2 className={styles["title"]}>Contributors</h2>
 			{isLoading && <Loader />}
-			{!isLoading && hasContributors && (
+			{isListShown && (
 				<ul className={styles["list"]}>
 					{contributors.map((contributor) => (
 						<li key={contributor.id}>
@@ -29,7 +31,7 @@ const ContributorsList = ({
 					))}
 				</ul>
 			)}
-			{!isLoading && !hasContributors && (
+			{isEmptyPlaceholderShown && (
 				<p className={styles["empty-placeholder"]}>
 					There are no contributors at the moment. Please set up analytics if
 					you haven&#39;t already.

--- a/apps/frontend/src/pages/project/libs/components/contributors-list/contributors-list.tsx
+++ b/apps/frontend/src/pages/project/libs/components/contributors-list/contributors-list.tsx
@@ -1,4 +1,5 @@
 import { Loader } from "~/libs/components/components.js";
+import { EMPTY_LENGTH } from "~/libs/constants/constants.js";
 import { type ContributorGetAllItemResponseDto } from "~/pages/project/libs/types/types.js";
 
 import { ContributorCard } from "../components.js";
@@ -13,12 +14,13 @@ const ContributorsList = ({
 	contributors,
 	isLoading,
 }: Properties): JSX.Element => {
+	const hasContributors = contributors.length > EMPTY_LENGTH;
+
 	return (
 		<div className={styles["container"]}>
 			<h2 className={styles["title"]}>Contributors</h2>
-			{isLoading ? (
-				<Loader />
-			) : (
+			{isLoading && <Loader />}
+			{!isLoading && hasContributors && (
 				<ul className={styles["list"]}>
 					{contributors.map((contributor) => (
 						<li key={contributor.id}>
@@ -26,6 +28,12 @@ const ContributorsList = ({
 						</li>
 					))}
 				</ul>
+			)}
+			{!isLoading && !hasContributors && (
+				<p className={styles["empty-placeholder"]}>
+					There are no contributors at the moment. Please set up analytics if
+					you haven&#39;t already.
+				</p>
 			)}
 		</div>
 	);

--- a/apps/frontend/src/pages/project/libs/components/contributors-list/styles.module.css
+++ b/apps/frontend/src/pages/project/libs/components/contributors-list/styles.module.css
@@ -22,6 +22,7 @@
 
 .empty-placeholder {
 	align-self: center;
+	margin-top: 150px;
 	font-size: 16px;
 	font-weight: 400;
 	line-height: 150%;

--- a/apps/frontend/src/pages/project/libs/components/contributors-list/styles.module.css
+++ b/apps/frontend/src/pages/project/libs/components/contributors-list/styles.module.css
@@ -19,3 +19,11 @@
 	padding: 0;
 	list-style-type: none;
 }
+
+.empty-placeholder {
+	align-self: center;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 150%;
+	color: var(--color-text-secondary);
+}


### PR DESCRIPTION
Added a placeholder, which looks like this:

<img width="1252" alt="Screenshot 2024-09-18 at 13 36 09" src="https://github.com/user-attachments/assets/774d78c3-03f4-45b7-8498-9c8e6e742112">

P.S. had to split conditions in order to get rid of linter problems. Linter does not allow to nest ternary expression without parentheses, but formatter wants that expression without them. If there is a better solution, please suggest it.