### PR TITLE
feat: Add instructions on how to setup analytics gf-343

### DIFF
--- a/apps/frontend/src/pages/project/libs/components/setup-analytics-modal/setup-analytics-modal.tsx
+++ b/apps/frontend/src/pages/project/libs/components/setup-analytics-modal/setup-analytics-modal.tsx
@@ -11,6 +11,7 @@ import {
 	useAppSelector,
 	useCallback,
 	useEffect,
+	useMemo,
 } from "~/libs/hooks/hooks.js";
 import { actions as projectApiKeyActions } from "~/modules/project-api-keys/project-api-keys.js";
 import { type ProjectGetByIdResponseDto } from "~/modules/projects/projects.js";
@@ -29,18 +30,32 @@ const SetupAnalyticsModal = ({
 	project,
 }: Properties): JSX.Element => {
 	const dispatch = useAppDispatch();
+
+	const { dataStatus } = useAppSelector(({ projectApiKeys }) => projectApiKeys);
+	const { authenticatedUser } = useAppSelector(({ auth }) => auth);
+
+	const hasProjectApiKey = project.apiKey !== null;
+	const hasAuthenticatedUser = authenticatedUser !== null;
+
+	const isGenerateButtonDisabled = dataStatus === DataStatus.PENDING;
+	const isCopyButtonDisabled =
+		!hasProjectApiKey || dataStatus === DataStatus.PENDING;
+
+	const script = useMemo<string>(
+		() =>
+			hasProjectApiKey && hasAuthenticatedUser
+				? `npx @git-fit/analytics@latest track ${project.apiKey as string} ${String(authenticatedUser.id)} <project-path>`
+				: "",
+		[hasProjectApiKey, hasAuthenticatedUser, project, authenticatedUser],
+	);
+
 	const { control, errors, handleSubmit, handleValueSet } = useAppForm({
 		defaultValues: {
 			apiKey: project.apiKey ?? "",
 			projectId: project.id,
+			script,
 		},
 	});
-	const { dataStatus } = useAppSelector(({ projectApiKeys }) => projectApiKeys);
-
-	const hasProjectApiKey = project.apiKey !== null;
-	const isGenerateButtonDisabled = dataStatus === DataStatus.PENDING;
-	const isCopyButtonDisabled =
-		!hasProjectApiKey || dataStatus === DataStatus.PENDING;
 
 	const handleGenerateSubmit = useCallback(
 		(event_: React.BaseSyntheticEvent): void => {
@@ -51,19 +66,40 @@ const SetupAnalyticsModal = ({
 		[handleSubmit, dispatch],
 	);
 
-	const handleCopyToClipboardClick = useCallback(() => {
-		void dispatch(
-			projectApiKeyActions.copyToClipboard(project.apiKey as string),
-		);
-	}, [dispatch, project.apiKey]);
+	const handleCopyToClipboard = useCallback(
+		(input: string) => {
+			void dispatch(projectApiKeyActions.copyToClipboard(input));
+		},
+		[dispatch],
+	);
+
+	const handleCopyAPIKeyClick = useCallback(() => {
+		handleCopyToClipboard(project.apiKey as string);
+	}, [handleCopyToClipboard, project]);
+
+	const handleCopyScriptClick = useCallback(() => {
+		handleCopyToClipboard(script);
+	}, [handleCopyToClipboard, script]);
 
 	useEffect(() => {
 		handleValueSet("apiKey", project.apiKey ?? "");
 	}, [handleValueSet, project.apiKey]);
 
+	useEffect(() => {
+		handleValueSet("script", script);
+	}, [handleValueSet, script]);
+
 	return (
 		<Modal isOpened={isOpened} onClose={onClose} title="Setup Analytics">
 			<div className={styles["content"]}>
+				<div>
+					<span className={styles["subtitle"]}>Overview</span>
+					<p className={styles["text"]}>
+						This script operates continuously in the background, collecting
+						statistics and updating analytics data every 3 hours.
+					</p>
+				</div>
+
 				<form
 					className={styles["api-key-container"]}
 					onSubmit={handleGenerateSubmit}
@@ -80,7 +116,7 @@ const SetupAnalyticsModal = ({
 								iconName="clipboard"
 								isDisabled={isCopyButtonDisabled}
 								label="Copy API key"
-								onClick={handleCopyToClipboardClick}
+								onClick={handleCopyAPIKeyClick}
 							/>
 						}
 					/>
@@ -92,6 +128,71 @@ const SetupAnalyticsModal = ({
 						/>
 					</div>
 				</form>
+
+				<div>
+					<span className={styles["subtitle"]}>Prerequisites</span>
+					<ul className={styles["text"]}>
+						<li>
+							<span className={styles["list-item-title"]}>Git</span>: Ensure Git
+							is installed for repository management.
+						</li>
+						<li>
+							<span className={styles["list-item-title"]}>Node.js 20</span>: The
+							script requires Node.js 20 to be installed on your machine.
+						</li>
+					</ul>
+				</div>
+
+				<div>
+					<span className={styles["subtitle"]}>Installation Steps</span>
+					<ol className={styles["text"]}>
+						<li className={styles["list-item"]}>
+							<span className={styles["list-item-title"]}>
+								Clone your project repository.
+							</span>
+							<p className={styles["list-item-text"]}>
+								Use Git to clone your project repository to your local machine.
+							</p>
+						</li>
+
+						<li className={styles["list-item"]}>
+							<span className={styles["list-item-title"]}>
+								Prepare the script.
+							</span>
+							<p className={styles["list-item-text"]}>
+								Copy the command below and modify with your local
+								repository&apos;s path:
+							</p>
+							<Input
+								control={control}
+								errors={errors}
+								isLabelHidden
+								isReadOnly
+								label="Script"
+								name="script"
+								placeholder="Need to generate API key"
+								rightIcon={
+									<IconButton
+										iconName="clipboard"
+										isDisabled={isCopyButtonDisabled}
+										label="Copy script"
+										onClick={handleCopyScriptClick}
+									/>
+								}
+							/>
+						</li>
+
+						<li className={styles["list-item"]}>
+							<span className={styles["list-item-title"]}>
+								Execute the script.
+							</span>
+							<p className={styles["list-item-text"]}>
+								Open your terminal or console, paste and run the modified
+								script.
+							</p>
+						</li>
+					</ol>
+				</div>
 			</div>
 		</Modal>
 	);

--- a/apps/frontend/src/pages/project/libs/components/setup-analytics-modal/styles.module.css
+++ b/apps/frontend/src/pages/project/libs/components/setup-analytics-modal/styles.module.css
@@ -4,10 +4,18 @@
 	gap: 24px;
 }
 
+.subtitle {
+	font-family: Inter, sans-serif;
+	font-size: 16px;
+	font-weight: 500;
+	line-height: 1.2;
+}
+
 .text {
 	font-family: Inter, sans-serif;
 	font-size: 16px;
 	font-weight: 400;
+	text-align: justify;
 }
 
 .api-key-container {
@@ -18,4 +26,17 @@
 
 .button-wrapper {
 	min-width: 120px;
+}
+
+.list-item {
+	margin-bottom: 16px;
+}
+
+.list-item-title {
+	margin-bottom: 0;
+	font-weight: 700;
+}
+
+.list-item-text {
+	margin: 0;
 }


### PR DESCRIPTION
- added instructions on how to setup analytics to the Setup Analytics modal
- API key and user id in the script are pre-populated with the current values
- button in the script field to copy text

![image](https://github.com/user-attachments/assets/76574d39-dee3-4fcc-83bc-9a710133d5f6)

For **not** generated API key:
![image](https://github.com/user-attachments/assets/711f0503-2fc4-4764-9801-98db7ac4505b)
