### PR TITLE
feat: add users column to groups table on project access management page gf-403

### DIFF
--- a/apps/frontend/src/pages/project-access-management/libs/helpers/get-project-group-columns.helper.tsx
+++ b/apps/frontend/src/pages/project-access-management/libs/helpers/get-project-group-columns.helper.tsx
@@ -20,6 +20,10 @@ const getProjectGroupColumns = (actions: {
 		header: "Permissions",
 	},
 	{
+		accessorKey: "userCount",
+		header: "Users",
+	},
+	{
 		accessorFn: (projectGroup: ProjectGroupRow): string =>
 			formatDate(new Date(projectGroup.createdAt), "d MMM yyyy HH:mm"),
 		header: "Created At",

--- a/apps/frontend/src/pages/project-access-management/libs/helpers/get-project-group-columns.helper.tsx
+++ b/apps/frontend/src/pages/project-access-management/libs/helpers/get-project-group-columns.helper.tsx
@@ -13,20 +13,24 @@ const getProjectGroupColumns = (actions: {
 	{
 		accessorKey: "name",
 		header: "Name",
+		size: 200,
 	},
 	{
 		accessorFn: (projectGroup: ProjectGroupRow): string =>
 			projectGroup.permissions.join(", "),
 		header: "Permissions",
+		size: 250,
 	},
 	{
 		accessorKey: "userCount",
 		header: "Users",
+		size: 100,
 	},
 	{
 		accessorFn: (projectGroup: ProjectGroupRow): string =>
 			formatDate(new Date(projectGroup.createdAt), "d MMM yyyy HH:mm"),
 		header: "Created At",
+		size: 200,
 	},
 	{
 		cell: ({ row: { original: projectGroup } }) => (

--- a/apps/frontend/src/pages/project-access-management/libs/helpers/get-project-group-rows.helper.tsx
+++ b/apps/frontend/src/pages/project-access-management/libs/helpers/get-project-group-rows.helper.tsx
@@ -10,6 +10,7 @@ const getProjectGroupRows = (
 		id: projectGroup.id,
 		name: projectGroup.name,
 		permissions: projectGroup.permissions.map((permission) => permission.name),
+		userCount: projectGroup.users.length,
 	}));
 
 export { getProjectGroupRows };

--- a/apps/frontend/src/pages/project-access-management/libs/types/project-group-row.type.ts
+++ b/apps/frontend/src/pages/project-access-management/libs/types/project-group-row.type.ts
@@ -3,6 +3,7 @@ type ProjectGroupRow = {
 	id: number;
 	name: string;
 	permissions: string[];
+	userCount: number;
 };
 
 export { type ProjectGroupRow };

--- a/apps/frontend/src/pages/project-access-management/project-access-management.tsx
+++ b/apps/frontend/src/pages/project-access-management/project-access-management.tsx
@@ -192,9 +192,10 @@ const ProjectAccessManagement = (): JSX.Element => {
 
 	useEffect(() => {
 		if (projectGroupCreateStatus === DataStatus.FULFILLED) {
+			handleLoadUsers();
 			onCreateModalClose();
 		}
-	}, [projectGroupCreateStatus, onCreateModalClose]);
+	}, [projectGroupCreateStatus, onCreateModalClose, handleLoadUsers]);
 
 	useEffect(() => {
 		if (projectGroupUpdateStatus === DataStatus.FULFILLED) {


### PR DESCRIPTION
- added users column to groups table on project access management page.

### Screenshots

![image](https://github.com/user-attachments/assets/a92d0efa-862f-463f-a46e-122b48fce116)
