### PR TITLE
fix: The Users table in the Create Projects Group Modal appearance is incorrect for the 1440px and 1024px screen resolution gf-389

### DIFF
--- a/apps/frontend/src/pages/project-access-management/libs/components/project-group-users-table/libs/helpers/get-group-users-columns.helper.ts
+++ b/apps/frontend/src/pages/project-access-management/libs/components/project-group-users-table/libs/helpers/get-group-users-columns.helper.ts
@@ -7,18 +7,18 @@ const getGroupUsersColumns = (): TableColumn<UserRow>[] => {
 		{
 			accessorKey: "name",
 			header: "Name",
-			size: 200,
+			size: 160,
 		},
 		{
 			accessorFn: (user: UserRow): string => user.projectGroups.join(", "),
 			header: "Groups",
-			size: 450,
+			size: 220,
 		},
 		{
 			accessorFn: (user: UserRow): string =>
 				formatDate(new Date(user.createdAt), "d MMM yyyy HH:mm"),
 			header: "Created At",
-			size: 200,
+			size: 160,
 		},
 	];
 };


### PR DESCRIPTION
Now  the table looks like at the main Access Management page
Preview: 
![image](https://github.com/user-attachments/assets/df61b5ae-0863-46ce-b2db-6f06041a6f91)
![image](https://github.com/user-attachments/assets/78a78696-b9c9-449c-b56c-9cf8ea0666d3)
