### PR TITLE
fix: The Options popover in unaccessible when opened on Contributors and Access Managment (both Root and Projects one) pages gf-436

### DIFF
--- a/apps/frontend/src/libs/components/table/styles.module.css
+++ b/apps/frontend/src/libs/components/table/styles.module.css
@@ -41,11 +41,14 @@
 
 .table-data {
 	min-height: 60px;
-	overflow: hidden;
 	font-weight: 400;
 	line-height: 150%;
-	text-overflow: ellipsis;
 	word-wrap: normal;
+}
+
+.text-data-wrapper {
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .table-header {

--- a/apps/frontend/src/libs/components/table/table.tsx
+++ b/apps/frontend/src/libs/components/table/table.tsx
@@ -139,7 +139,16 @@ const Table = <T extends object>({
 										key={cell.id}
 										style={{ width: cell.column.columnDef.size }}
 									>
-										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+										{typeof cell.getContext().getValue() === "string" ? (
+											<div className={styles["text-data-wrapper"]}>
+												{flexRender(
+													cell.column.columnDef.cell,
+													cell.getContext(),
+												)}
+											</div>
+										) : (
+											flexRender(cell.column.columnDef.cell, cell.getContext())
+										)}
 									</td>
 								))}
 							</tr>


### PR DESCRIPTION
## Fixes
- Fixed popover appearance in all the tables
- Ellipsis text overflow now shouldn't be rendered on check-box column

## Screenshots
![image](https://github.com/user-attachments/assets/a1dfe155-6667-400b-b99a-1ce0d6fe25b9)
![image](https://github.com/user-attachments/assets/444084bb-7a50-48c8-a70d-391f45e05b5b)

## P.s.
Ellipsis text overflow now appears only in columns holding text values
![image](https://github.com/user-attachments/assets/bb3a95c5-4eef-49ff-90f1-a0e772e1c0da)
![image](https://github.com/user-attachments/assets/28416737-3039-40a1-8882-7a24a56d4a47)
![image](https://github.com/user-attachments/assets/a013c79f-20e2-4b5c-ba64-107d31b649fd)


## Questions
Should ellipsis text overflow appear in columns holding number values?