### PR TITLE
fix: Inconsistent Users table resolution on the Access managment page on 1440px screen resolution gf-448

### DIFF
--- a/apps/frontend/src/pages/access-management/libs/helpers/get-user-columns/get-user-columns.helper.tsx
+++ b/apps/frontend/src/pages/access-management/libs/helpers/get-user-columns/get-user-columns.helper.tsx
@@ -16,7 +16,7 @@ const getUserColumns = (actions: {
 		{
 			accessorFn: (user: UserRow): string => user.groups.join(", "),
 			header: "Groups",
-			size: 460,
+			size: 400,
 		},
 		{
 			accessorFn: (user: UserRow): string =>


### PR DESCRIPTION
## Fixes
- Adjusted column sizes so the table fit 1440px screen resolution without horizontal scrollbar appeared

## Screenshots
![image](https://github.com/user-attachments/assets/24b527c2-51f9-4306-95d1-00f691d90f33)