### PR TITLE
fix: Inconsistent Users table resolution on the Project Access managment page on 1440px screen resolution gf-448

### DIFF
--- a/apps/frontend/src/pages/project-access-management/libs/helpers/get-user-columns/get-user-columns.helper.ts
+++ b/apps/frontend/src/pages/project-access-management/libs/helpers/get-user-columns/get-user-columns.helper.ts
@@ -13,7 +13,7 @@ const getUserColumns = (): TableColumn<UserRow>[] => {
 		{
 			accessorFn: (user: UserRow): string => user.projectGroups.join(", "),
 			header: "Groups",
-			size: 500,
+			size: 400,
 		},
 		{
 			accessorFn: (user: UserRow): string =>


### PR DESCRIPTION
## Fixes
- Adjusted column size so table fits 1440px screen resolution without horizontal scroll appeared

## Screenshots
![image](https://github.com/user-attachments/assets/2cc74773-519b-43d8-bc75-a92326850904)
