### PR TITLE
feat: Add an activity chart to contributor items on project details page gf-420

### DIFF
--- a/apps/backend/src/modules/activity-logs/activity-log.controller.ts
+++ b/apps/backend/src/modules/activity-logs/activity-log.controller.ts
@@ -168,13 +168,8 @@ class ActivityLogController extends BaseController {
 			query: ActivityLogQueryParameters;
 		}>,
 	): Promise<APIHandlerResponse> {
-		const { endDate, startDate } = options.query;
-
 		return {
-			payload: await this.activityLogService.findAll({
-				endDate,
-				startDate,
-			}),
+			payload: await this.activityLogService.findAll(options.query),
 			status: HTTPCode.OK,
 		};
 	}

--- a/apps/backend/src/modules/activity-logs/activity-log.repository.ts
+++ b/apps/backend/src/modules/activity-logs/activity-log.repository.ts
@@ -42,9 +42,10 @@ class ActivityLogRepository implements Repository {
 
 	public async findAll({
 		endDate,
+		projectId,
 		startDate,
 	}: ActivityLogQueryParameters): Promise<{ items: ActivityLogEntity[] }> {
-		const activityLogs = await this.activityLogModel
+		let query = this.activityLogModel
 			.query()
 			.withGraphFetched("[gitEmail.contributor, project, createdByUser]")
 			.modifyGraph("gitEmail.contributor", (builder) => {
@@ -52,6 +53,12 @@ class ActivityLogRepository implements Repository {
 			})
 			.whereBetween("activity_logs.date", [startDate, endDate])
 			.orderBy("date");
+
+		if (projectId) {
+			query = query.where("project_id", projectId);
+		}
+
+		const activityLogs = await query.execute();
 
 		return {
 			items: activityLogs.map((activityLog) =>

--- a/apps/backend/src/modules/activity-logs/activity-log.service.ts
+++ b/apps/backend/src/modules/activity-logs/activity-log.service.ts
@@ -133,17 +133,23 @@ class ActivityLogService implements Service {
 
 	public async findAll({
 		endDate,
+		projectId,
 		startDate,
 	}: ActivityLogQueryParameters): Promise<ActivityLogGetAllAnalyticsResponseDto> {
 		const activityLogsEntities = await this.activityLogRepository.findAll({
 			endDate,
+			projectId,
 			startDate,
 		});
 
 		const activityLogs = activityLogsEntities.items.map((item) =>
 			item.toObject(),
 		);
-		const allContributors = await this.contributorService.findAll();
+
+		const allContributors = await (projectId
+			? this.contributorService.findAllByProjectId(Number(projectId))
+			: this.contributorService.findAll());
+
 		const dateRange = getDateRange(startDate, endDate);
 
 		const INITIAL_COMMITS_NUMBER = 0;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -29,7 +29,8 @@
 		"react-redux": "9.1.2",
 		"react-router-dom": "6.26.0",
 		"react-select": "5.8.0",
-		"react-toastify": "10.0.5"
+		"react-toastify": "10.0.5",
+		"recharts": "2.12.7"
 	},
 	"devDependencies": {
 		"@types/react": "18.3.3",

--- a/apps/frontend/src/libs/components/activity-chart/activity-chart.tsx
+++ b/apps/frontend/src/libs/components/activity-chart/activity-chart.tsx
@@ -1,0 +1,22 @@
+import { Line, LineChart } from "recharts";
+
+import { type ActivityChartData } from "./libs/types/types.js";
+
+type Properties = {
+	data: ActivityChartData;
+};
+
+const ActivityChart = ({ data }: Properties): JSX.Element => {
+	return (
+		<LineChart data={data} height={40} width={120}>
+			<Line
+				dataKey="commitsNumber"
+				dot={false}
+				stroke="var(--color-brand-primary)"
+				strokeWidth={3}
+			/>
+		</LineChart>
+	);
+};
+
+export { ActivityChart };

--- a/apps/frontend/src/libs/components/activity-chart/libs/types/activity-chart-data.type.ts
+++ b/apps/frontend/src/libs/components/activity-chart/libs/types/activity-chart-data.type.ts
@@ -1,0 +1,5 @@
+type ActivityChartData = {
+	commitsNumber: number;
+}[];
+
+export { type ActivityChartData };

--- a/apps/frontend/src/libs/components/activity-chart/libs/types/types.ts
+++ b/apps/frontend/src/libs/components/activity-chart/libs/types/types.ts
@@ -1,0 +1,1 @@
+export { type ActivityChartData } from "./activity-chart-data.type.js";

--- a/apps/frontend/src/libs/components/components.ts
+++ b/apps/frontend/src/libs/components/components.ts
@@ -1,3 +1,4 @@
+export { ActivityChart } from "./activity-chart/activity-chart.js";
 export { ActivityIndicator } from "./activity-indicator/activity-indicator.js";
 export { App } from "./app/app.js";
 export { Avatar } from "./avatar/avatar.js";

--- a/apps/frontend/src/modules/activity/activity-logs-api.ts
+++ b/apps/frontend/src/modules/activity/activity-logs-api.ts
@@ -23,15 +23,20 @@ class ActivityLogApi extends BaseHTTPApi {
 	public async getAll(
 		query: ActivityLogQueryParameters,
 	): Promise<ActivityLogGetAllAnalyticsResponseDto> {
+		const { endDate, projectId, startDate } = query;
+
+		const queryToSend = {
+			endDate,
+			startDate,
+			...(projectId ? { projectId } : {}),
+		};
+
 		const response = await this.load(
 			this.getFullEndpoint(ActivityLogsApiPath.ROOT, {}),
 			{
 				hasAuth: true,
 				method: "GET",
-				query: {
-					endDate: String(query.endDate),
-					startDate: String(query.startDate),
-				},
+				query: queryToSend,
 			},
 		);
 

--- a/apps/frontend/src/modules/activity/activity.ts
+++ b/apps/frontend/src/modules/activity/activity.ts
@@ -16,5 +16,6 @@ export {
 	type ActivityLogGetAllItemAnalyticsResponseDto,
 	type ActivityLogGetAllItemResponseDto,
 	type ActivityLogGetAllResponseDto,
+	type ActivityLogQueryParameters,
 } from "./libs/types/types.js";
 export { actions, reducer } from "./slices/activity.js";

--- a/apps/frontend/src/modules/projects/slices/actions.ts
+++ b/apps/frontend/src/modules/projects/slices/actions.ts
@@ -2,6 +2,10 @@ import { createAsyncThunk } from "@reduxjs/toolkit";
 
 import { NotificationMessage } from "~/libs/enums/enums.js";
 import { type AsyncThunkConfig } from "~/libs/types/types.js";
+import {
+	type ActivityLogGetAllAnalyticsResponseDto,
+	type ActivityLogQueryParameters,
+} from "~/modules/activity/activity.js";
 import { type ContributorGetAllResponseDto } from "~/modules/contributors/contributors.js";
 import {
 	type ProjectCreateRequestDto,
@@ -91,11 +95,25 @@ const loadAllContributorsByProjectId = createAsyncThunk<
 	},
 );
 
+const loadAllContributorsActivityByProjectId = createAsyncThunk<
+	ActivityLogGetAllAnalyticsResponseDto,
+	ActivityLogQueryParameters,
+	AsyncThunkConfig
+>(
+	`${sliceName}/load-all-contributors-activity-by-project-id`,
+	async (query, { extra }) => {
+		const { activityLogApi } = extra;
+
+		return await activityLogApi.getAll(query);
+	},
+);
+
 export {
 	create,
 	deleteById,
 	getById,
 	loadAll,
+	loadAllContributorsActivityByProjectId,
 	loadAllContributorsByProjectId,
 	patch,
 };

--- a/apps/frontend/src/modules/projects/slices/project.slice.ts
+++ b/apps/frontend/src/modules/projects/slices/project.slice.ts
@@ -3,6 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import { ITEMS_CHANGED_COUNT } from "~/libs/constants/constants.js";
 import { DataStatus } from "~/libs/enums/enums.js";
 import { type ValueOf } from "~/libs/types/types.js";
+import { type ActivityLogGetAllItemAnalyticsResponseDto } from "~/modules/activity/activity.js";
 import { type ContributorGetAllItemResponseDto } from "~/modules/contributors/contributors.js";
 import { actions as projectApiKeyActions } from "~/modules/project-api-keys/project-api-keys.js";
 import {
@@ -16,6 +17,7 @@ import {
 	deleteById,
 	getById,
 	loadAll,
+	loadAllContributorsActivityByProjectId,
 	loadAllContributorsByProjectId,
 	patch,
 } from "./actions.js";
@@ -24,6 +26,7 @@ type State = {
 	dataStatus: ValueOf<typeof DataStatus>;
 	project: null | ProjectGetByIdResponseDto;
 	projectContributors: ContributorGetAllItemResponseDto[];
+	projectContributorsActivity: ActivityLogGetAllItemAnalyticsResponseDto[];
 	projectContributorsStatus: ValueOf<typeof DataStatus>;
 	projectCreateStatus: ValueOf<typeof DataStatus>;
 	projectDeleteStatus: ValueOf<typeof DataStatus>;
@@ -37,6 +40,7 @@ const initialState: State = {
 	dataStatus: DataStatus.IDLE,
 	project: null,
 	projectContributors: [],
+	projectContributorsActivity: [],
 	projectContributorsStatus: DataStatus.IDLE,
 	projectCreateStatus: DataStatus.IDLE,
 	projectDeleteStatus: DataStatus.IDLE,
@@ -132,6 +136,18 @@ const { actions, name, reducer } = createSlice({
 			state.projectContributors = [];
 			state.projectContributorsStatus = DataStatus.REJECTED;
 		});
+		builder.addCase(
+			loadAllContributorsActivityByProjectId.fulfilled,
+			(state, action) => {
+				state.projectContributorsActivity = action.payload.items;
+			},
+		);
+		builder.addCase(
+			loadAllContributorsActivityByProjectId.rejected,
+			(state) => {
+				state.projectContributorsActivity = [];
+			},
+		);
 	},
 	initialState,
 	name: "projects",

--- a/apps/frontend/src/modules/projects/slices/projects.ts
+++ b/apps/frontend/src/modules/projects/slices/projects.ts
@@ -3,6 +3,7 @@ import {
 	deleteById,
 	getById,
 	loadAll,
+	loadAllContributorsActivityByProjectId,
 	loadAllContributorsByProjectId,
 	patch,
 } from "./actions.js";
@@ -14,6 +15,7 @@ const allActions = {
 	deleteById,
 	getById,
 	loadAll,
+	loadAllContributorsActivityByProjectId,
 	loadAllContributorsByProjectId,
 	patch,
 };

--- a/apps/frontend/src/pages/project/libs/components/contributor-card/contributor-card.tsx
+++ b/apps/frontend/src/pages/project/libs/components/contributor-card/contributor-card.tsx
@@ -9,17 +9,25 @@ import {
 	getStartOfDay,
 } from "~/libs/helpers/helpers.js";
 import { useCallback } from "~/libs/hooks/hooks.js";
+import { type ActivityLogGetAllItemAnalyticsResponseDto } from "~/modules/activity/activity.js";
 import { type ContributorGetAllItemResponseDto } from "~/pages/project/libs/types/types.js";
 
 import { ContributorMenu } from "../components.js";
 import styles from "./styles.module.css";
 
 type Properties = {
+	activityLog?:
+		| ActivityLogGetAllItemAnalyticsResponseDto["commitsNumber"]
+		| undefined;
 	contributor: ContributorGetAllItemResponseDto;
 	onEdit: (contributorId: number) => void;
 };
 
-const ContributorCard = ({ contributor, onEdit }: Properties): JSX.Element => {
+const ContributorCard = ({
+	activityLog,
+	contributor,
+	onEdit,
+}: Properties): JSX.Element => {
 	const currentDate = getStartOfDay(new Date());
 	const lastActivityDate = contributor.lastActivityDate
 		? getStartOfDay(new Date(contributor.lastActivityDate))
@@ -40,12 +48,11 @@ const ContributorCard = ({ contributor, onEdit }: Properties): JSX.Element => {
 
 	const hasActivityIndicator = lastUpdateLabel !== null && colorStatus !== null;
 
-	// TODO: replace this mock data with actual activity data
-	const ONE = 1;
-	const FIVE = 5;
-	const activityData = [...Array.from({ length: 30 }).keys()].map(() => ({
-		commitsNumber: Math.floor((Math.random() + ONE) * FIVE),
-	}));
+	const hasActivityData = Boolean(activityLog);
+	const activityData =
+		activityLog?.map((commitsNumber) => ({
+			commitsNumber,
+		})) ?? [];
 
 	const handleEditClick = useCallback(() => {
 		onEdit(contributor.id);
@@ -57,7 +64,7 @@ const ContributorCard = ({ contributor, onEdit }: Properties): JSX.Element => {
 			{hasActivityIndicator && (
 				<ActivityIndicator label={lastUpdateLabel} status={colorStatus} />
 			)}
-			<ActivityChart data={activityData} />
+			{hasActivityData && <ActivityChart data={activityData} />}
 			<ContributorMenu
 				contributorId={contributor.id}
 				onEdit={handleEditClick}

--- a/apps/frontend/src/pages/project/libs/components/contributor-card/contributor-card.tsx
+++ b/apps/frontend/src/pages/project/libs/components/contributor-card/contributor-card.tsx
@@ -1,4 +1,7 @@
-import { ActivityIndicator } from "~/libs/components/components.js";
+import {
+	ActivityChart,
+	ActivityIndicator,
+} from "~/libs/components/components.js";
 import {
 	getActivityIndicatorStatus,
 	getDifferenceInDays,
@@ -37,6 +40,13 @@ const ContributorCard = ({ contributor, onEdit }: Properties): JSX.Element => {
 
 	const hasActivityIndicator = lastUpdateLabel !== null && colorStatus !== null;
 
+	// TODO: replace this mock data with actual activity data
+	const ONE = 1;
+	const FIVE = 5;
+	const activityData = [...Array.from({ length: 30 }).keys()].map(() => ({
+		commitsNumber: Math.floor((Math.random() + ONE) * FIVE),
+	}));
+
 	const handleEditClick = useCallback(() => {
 		onEdit(contributor.id);
 	}, [onEdit, contributor.id]);
@@ -47,6 +57,7 @@ const ContributorCard = ({ contributor, onEdit }: Properties): JSX.Element => {
 			{hasActivityIndicator && (
 				<ActivityIndicator label={lastUpdateLabel} status={colorStatus} />
 			)}
+			<ActivityChart data={activityData} />
 			<ContributorMenu
 				contributorId={contributor.id}
 				onEdit={handleEditClick}

--- a/apps/frontend/src/pages/project/libs/components/contributor-card/styles.module.css
+++ b/apps/frontend/src/pages/project/libs/components/contributor-card/styles.module.css
@@ -1,5 +1,6 @@
 .card {
 	display: flex;
+	gap: 12px;
 	align-items: center;
 	justify-content: space-between;
 	width: 100%;

--- a/apps/frontend/src/pages/project/libs/components/contributors-list/contributors-list.tsx
+++ b/apps/frontend/src/pages/project/libs/components/contributors-list/contributors-list.tsx
@@ -1,18 +1,21 @@
 import { Loader } from "~/libs/components/components.js";
 import { EMPTY_LENGTH } from "~/libs/constants/constants.js";
 import { useCallback } from "~/libs/hooks/hooks.js";
+import { type ActivityLogGetAllItemAnalyticsResponseDto } from "~/modules/activity/activity.js";
 import { type ContributorGetAllItemResponseDto } from "~/pages/project/libs/types/types.js";
 
 import { ContributorCard } from "../components.js";
 import styles from "./styles.module.css";
 
 type Properties = {
+	activityLogs: ActivityLogGetAllItemAnalyticsResponseDto[];
 	contributors: ContributorGetAllItemResponseDto[];
 	isLoading: boolean;
 	onEditContributor: (contributorId: number) => void;
 };
 
 const ContributorsList = ({
+	activityLogs,
 	contributors,
 	isLoading,
 	onEditContributor,
@@ -37,6 +40,12 @@ const ContributorsList = ({
 					{contributors.map((contributor) => (
 						<li key={contributor.id}>
 							<ContributorCard
+								activityLog={
+									activityLogs.find(
+										(activityLog) =>
+											Number(activityLog.contributorId) === contributor.id,
+									)?.commitsNumber
+								}
 								contributor={contributor}
 								onEdit={handleEditContributor}
 							/>

--- a/apps/frontend/src/pages/project/project.tsx
+++ b/apps/frontend/src/pages/project/project.tsx
@@ -7,7 +7,7 @@ import {
 	PageLayout,
 } from "~/libs/components/components.js";
 import { AppRoute, DataStatus, PermissionKey } from "~/libs/enums/enums.js";
-import { checkHasPermission } from "~/libs/helpers/helpers.js";
+import { checkHasPermission, subtractDays } from "~/libs/helpers/helpers.js";
 import {
 	useAppDispatch,
 	useAppSelector,
@@ -26,6 +26,7 @@ import {
 	actions as projectActions,
 	type ProjectPatchRequestDto,
 } from "~/modules/projects/projects.js";
+import { ANALYTICS_DATE_MAX_RANGE } from "~/pages/analytics/libs/constants/analytics-date-max-range.constant.js";
 import { ContributorUpdateForm } from "~/pages/contributors/libs/components/components.js";
 import { NotFound } from "~/pages/not-found/not-found.jsx";
 import { ProjectUpdateForm } from "~/pages/projects/libs/components/components.js";
@@ -46,6 +47,7 @@ const Project = (): JSX.Element => {
 	const {
 		project,
 		projectContributors,
+		projectContributorsActivity,
 		projectContributorsStatus,
 		projectDeleteStatus,
 		projectPatchStatus,
@@ -83,6 +85,20 @@ const Project = (): JSX.Element => {
 		if (projectId) {
 			void dispatch(projectActions.getById({ id: projectId }));
 			void dispatch(projectActions.loadAllContributorsByProjectId(projectId));
+
+			const todayDate = new Date();
+			const endDate = todayDate.toISOString();
+			const startDate = subtractDays(
+				todayDate,
+				ANALYTICS_DATE_MAX_RANGE,
+			).toISOString();
+			void dispatch(
+				projectActions.loadAllContributorsActivityByProjectId({
+					endDate,
+					projectId,
+					startDate,
+				}),
+			);
 		}
 	}, [dispatch, projectId]);
 
@@ -224,6 +240,7 @@ const Project = (): JSX.Element => {
 
 						<div className={styles["contributors-list-wrapper"]}>
 							<ContributorsList
+								activityLogs={projectContributorsActivity}
 								contributors={projectContributors}
 								isLoading={isContributorsDataLoading}
 								onEditContributor={handleEditContributor}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 		},
 		"apps/backend": {
 			"name": "@git-fit/backend",
-			"version": "1.28.1",
+			"version": "1.29.0",
 			"dependencies": {
 				"@fastify/static": "7.0.4",
 				"@fastify/swagger": "8.15.0",
@@ -133,7 +133,7 @@
 		},
 		"apps/frontend": {
 			"name": "@git-fit/frontend",
-			"version": "1.41.2",
+			"version": "1.43.0",
 			"dependencies": {
 				"@git-fit/shared": "*",
 				"@hookform/resolvers": "3.9.0",
@@ -147,7 +147,8 @@
 				"react-redux": "9.1.2",
 				"react-router-dom": "6.26.0",
 				"react-select": "5.8.0",
-				"react-toastify": "10.0.5"
+				"react-toastify": "10.0.5",
+				"recharts": "2.12.7"
 			},
 			"devDependencies": {
 				"@types/react": "18.3.3",
@@ -3319,6 +3320,60 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+			"integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+		},
+		"node_modules/@types/d3-interpolate": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+			"dependencies": {
+				"@types/d3-color": "*"
+			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+			"integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+			"integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+			"integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+		},
 		"node_modules/@types/eslint": {
 			"version": "8.56.11",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
@@ -5029,6 +5084,116 @@
 			"integrity": "sha512-yi1x3EAWKjQTreYWeSd98431AV+IEE0qoDyOoaHJ7KJ21gv6HtBXHVLX74opVSGqcR8/AbjJBHAHpcOy2bj5Gg==",
 			"license": "MIT"
 		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -5291,6 +5456,11 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js-light": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
 		},
 		"node_modules/deep-equal": {
 			"version": "2.2.3",
@@ -7070,6 +7240,14 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
+		"node_modules/fast-equals": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+			"integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/fast-glob": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -8181,6 +8359,14 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/interpret": {
@@ -11665,6 +11851,20 @@
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/react-smooth": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
+			"integrity": "sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==",
+			"dependencies": {
+				"fast-equals": "^5.0.1",
+				"prop-types": "^15.8.1",
+				"react-transition-group": "^4.4.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/react-toastify": {
 			"version": "10.0.5",
 			"resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
@@ -11869,6 +12069,41 @@
 			"engines": {
 				"node": ">= 12.13.0"
 			}
+		},
+		"node_modules/recharts": {
+			"version": "2.12.7",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
+			"integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
+			"dependencies": {
+				"clsx": "^2.0.0",
+				"eventemitter3": "^4.0.1",
+				"lodash": "^4.17.21",
+				"react-is": "^16.10.2",
+				"react-smooth": "^4.0.0",
+				"recharts-scale": "^0.4.4",
+				"tiny-invariant": "^1.3.1",
+				"victory-vendor": "^36.6.8"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/recharts-scale": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+			"integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+			"dependencies": {
+				"decimal.js-light": "^2.4.1"
+			}
+		},
+		"node_modules/recharts/node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
 		},
 		"node_modules/rechoir": {
 			"version": "0.8.0",
@@ -13556,6 +13791,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/tiny-invariant": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+		},
 		"node_modules/to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -13985,6 +14225,27 @@
 			"integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/victory-vendor": {
+			"version": "36.9.2",
+			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+			"integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+			"dependencies": {
+				"@types/d3-array": "^3.0.3",
+				"@types/d3-ease": "^3.0.0",
+				"@types/d3-interpolate": "^3.0.1",
+				"@types/d3-scale": "^4.0.2",
+				"@types/d3-shape": "^3.1.0",
+				"@types/d3-time": "^3.0.0",
+				"@types/d3-timer": "^3.0.0",
+				"d3-array": "^3.1.6",
+				"d3-ease": "^3.0.1",
+				"d3-interpolate": "^3.0.1",
+				"d3-scale": "^4.0.2",
+				"d3-shape": "^3.1.0",
+				"d3-time": "^3.0.0",
+				"d3-timer": "^3.0.1"
 			}
 		},
 		"node_modules/vite": {
@@ -14593,7 +14854,7 @@
 		},
 		"packages/shared": {
 			"name": "@git-fit/shared",
-			"version": "1.26.0",
+			"version": "1.27.0",
 			"dependencies": {
 				"change-case": "5.4.4",
 				"date-fns": "3.6.0",

--- a/packages/shared/src/modules/activity-logs/libs/types/activity-log-get-all-item-analytics-response-dto.type.ts
+++ b/packages/shared/src/modules/activity-logs/libs/types/activity-log-get-all-item-analytics-response-dto.type.ts
@@ -1,5 +1,5 @@
 type ActivityLogGetAllItemAnalyticsResponseDto = {
-	commitsNumber: (number | string)[];
+	commitsNumber: number[];
 	contributorId: string;
 	contributorName: string;
 };

--- a/packages/shared/src/modules/activity-logs/libs/types/activity-log-query-parameters.type.ts
+++ b/packages/shared/src/modules/activity-logs/libs/types/activity-log-query-parameters.type.ts
@@ -1,5 +1,6 @@
 type ActivityLogQueryParameters = {
 	endDate: string;
+	projectId?: string | undefined;
 	startDate: string;
 };
 

--- a/packages/shared/src/modules/activity-logs/libs/validation-schemas/activity-log-get.validation-schema.ts
+++ b/packages/shared/src/modules/activity-logs/libs/validation-schemas/activity-log-get.validation-schema.ts
@@ -7,6 +7,7 @@ const activityLogGet: z.ZodType<ActivityLogQueryParameters> = z.object({
 	endDate: z.string({
 		required_error: ActivityLogValidationMessage.END_DATE_REQUIRED,
 	}),
+	projectId: z.string().optional(),
 	startDate: z.string({
 		required_error: ActivityLogValidationMessage.START_DATE_REQUIRED,
 	}),


### PR DESCRIPTION
## Features
- created `ActivityChart` common component
- added `ActivityChart` to contributor cards on project details page, plotting contributor activity (commits number) during last month
- adjusted `getAll` activity logs method adding optional `projectId` query param, so you can get all logs relavent only to specific project

## Screenshots
![image](https://github.com/user-attachments/assets/bc6be402-ac8a-4c33-b3f9-5223881a665a)
![image](https://github.com/user-attachments/assets/40eeff04-d0c1-42c1-bad5-de2048527076)
![image](https://github.com/user-attachments/assets/33c428b4-5816-405d-bb5a-5da49f55328d)
