### PR TITLE
fix: inconsistent alignment of the analytics table on the analytics page gf-473

### DIFF
--- a/apps/frontend/src/pages/analytics/libs/components/analytics-table/analytics-table.tsx
+++ b/apps/frontend/src/pages/analytics/libs/components/analytics-table/analytics-table.tsx
@@ -29,7 +29,11 @@ const AnalyticsTable = ({
 
 	return (
 		<div className={styles["analytics-table"]}>
-			<Table<AnalyticsRow> columns={analyticsColumns} data={analyticsData} />
+			<Table<AnalyticsRow>
+				columns={analyticsColumns}
+				data={analyticsData}
+				isFullHeight
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
Analytics table is full screen for high resolution (2560px)