### PR TITLE
fix: the total number of users is not updated in the groups table after deleting a user gf-463

### DIFF
--- a/apps/backend/src/modules/groups/group.repository.ts
+++ b/apps/backend/src/modules/groups/group.repository.ts
@@ -65,7 +65,10 @@ class GroupRepository implements Repository {
 			.query()
 			.orderBy("createdAt", SortType.DESCENDING)
 			.page(page, pageSize)
-			.withGraphFetched("[permissions, users]");
+			.withGraphFetched("[permissions, users]")
+			.modifyGraph("users", (builder) => {
+				builder.whereNull("deletedAt");
+			});
 
 		return {
 			items: results.map((group) => GroupEntity.initialize(group)),

--- a/apps/backend/src/modules/project-groups/project-group.repository.ts
+++ b/apps/backend/src/modules/project-groups/project-group.repository.ts
@@ -75,7 +75,10 @@ class ProjectGroupRepository implements Repository {
 		const projectGroup = await this.projectGroupModel
 			.query()
 			.findById(id)
-			.withGraphFetched("[permissions, projects, users]");
+			.withGraphFetched("[permissions, projects, users]")
+			.modifyGraph("users", (builder) => {
+				builder.whereNull("deletedAt");
+			});
 
 		if (projectGroup) {
 			const [project] = projectGroup.projects as [ProjectModel];
@@ -103,7 +106,10 @@ class ProjectGroupRepository implements Repository {
 			.page(page, pageSize)
 			.joinRelated("projects")
 			.where("projects.id", id)
-			.withGraphFetched("[permissions, users, projects]");
+			.withGraphFetched("[permissions, users, projects]")
+			.modifyGraph("users", (builder) => {
+				builder.whereNull("deletedAt");
+			});
 
 		return {
 			items: results.map((projectGroup) =>


### PR DESCRIPTION
Fixed table updating after user deletion by filtering deleted users from the result of api response. 
Also this might be fixed by removing relations between deleted users and groups, but decided to do it the easier way. Additionally, if user account is recovered, his relations will be saved.