### PR TITLE
fix: loader component is not vertically centralized on the analytics page gf-471

### DIFF
--- a/apps/frontend/src/pages/analytics/analytics.tsx
+++ b/apps/frontend/src/pages/analytics/analytics.tsx
@@ -1,4 +1,4 @@
-import { DateInput, Loader, PageLayout } from "~/libs/components/components.js";
+import { DateInput, PageLayout } from "~/libs/components/components.js";
 import { DataStatus } from "~/libs/enums/enums.js";
 import { subtractDays } from "~/libs/helpers/helpers.js";
 import {
@@ -83,14 +83,11 @@ const Analytics = (): JSX.Element => {
 						name="dateRange"
 					/>
 				</form>
-				{isLoading ? (
-					<Loader />
-				) : (
-					<AnalyticsTable
-						activityLogs={activityLogs}
-						dateRange={dateRangeValue}
-					/>
-				)}
+				<AnalyticsTable
+					activityLogs={activityLogs}
+					dateRange={dateRangeValue}
+					isLoading={isLoading}
+				/>
 			</section>
 		</PageLayout>
 	);

--- a/apps/frontend/src/pages/analytics/libs/components/analytics-table/analytics-table.tsx
+++ b/apps/frontend/src/pages/analytics/libs/components/analytics-table/analytics-table.tsx
@@ -12,11 +12,13 @@ import styles from "./styles.module.css";
 type Properties = {
 	activityLogs: ActivityLogGetAllItemAnalyticsResponseDto[];
 	dateRange: [Date, Date];
+	isLoading: boolean;
 };
 
 const AnalyticsTable = ({
 	activityLogs,
 	dateRange,
+	isLoading,
 }: Properties): JSX.Element => {
 	const [startDate, endDate] = dateRange;
 	const dateRangeFormatted = getDateRange(startDate, endDate);
@@ -29,7 +31,11 @@ const AnalyticsTable = ({
 
 	return (
 		<div className={styles["analytics-table"]}>
-			<Table<AnalyticsRow> columns={analyticsColumns} data={analyticsData} />
+			<Table<AnalyticsRow>
+				columns={analyticsColumns}
+				data={analyticsData}
+				isLoading={isLoading}
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
Moved the loader to the table to follow the style of the project.
![image](https://github.com/user-attachments/assets/52c960f5-82b5-457e-89cd-c13e8301e5a5)
