### PR TITLE
fix: The table on the Analytics page reloads after a click on the date input to open the calendar gf-472

### DIFF
--- a/apps/frontend/src/libs/components/date-input/date-input.tsx
+++ b/apps/frontend/src/libs/components/date-input/date-input.tsx
@@ -101,7 +101,11 @@ const DateInput = <T extends FieldValues>({
 				isOpened={isOpened}
 				onClose={onClose}
 			>
-				<button className={styles["date-input-trigger"]} onClick={onOpen}>
+				<button
+					className={styles["date-input-trigger"]}
+					onClick={isOpened ? onClose : onOpen}
+					type="button"
+				>
 					<span className={styles["calendar-icon-wrapper"]}>
 						<Icon height={20} name="calendar" width={20} />
 					</span>

--- a/apps/frontend/src/libs/components/date-input/styles.module.css
+++ b/apps/frontend/src/libs/components/date-input/styles.module.css
@@ -113,6 +113,7 @@
 	width: 270px;
 	padding: 10px 16px;
 	color: inherit;
+	cursor: pointer;
 	background-color: var(--color-background-secondary);
 	border: 1px solid var(--color-border-primary);
 	border-radius: 6px;


### PR DESCRIPTION
## Fixes
Fixed `DateInput` component
- change type of trigger button to `button`, so it does not trigger form submission
- add `cursor: pointer` style
- when popover opened, pressing button closes it