### PR TITLE
fix: The sidebar's size is inconsistent and changes when navigating between different sidebar links gf-475

### DIFF
--- a/apps/frontend/src/libs/components/page-layout/styles.module.css
+++ b/apps/frontend/src/libs/components/page-layout/styles.module.css
@@ -27,7 +27,7 @@
 	position: sticky;
 	top: var(--header-height);
 	left: 0;
-	width: max(280px, 20%);
+	min-width: 280px;
 	max-height: calc(100vh - var(--header-height));
 }
 


### PR DESCRIPTION
## Fixes
- make sidebar width be same width on all pages and for all screen resolutions

## Screenshots
![image](https://github.com/user-attachments/assets/d91a0eef-7797-48cf-ac6f-32dcb1b5d54e)
![image](https://github.com/user-attachments/assets/3bd7132d-054e-47e1-aa98-11db0cb12741)
![image](https://github.com/user-attachments/assets/85b6b97a-a3e4-4259-84bb-d24ebaf920d2)
