### PR TITLE
fix: The "API key not found" is displayed in console after an attempt to setup the Analytics with a API key generated more than a day ago gf-495

### DIFF
--- a/apps/backend/src/libs/modules/encryption/base-encryption.module.ts
+++ b/apps/backend/src/libs/modules/encryption/base-encryption.module.ts
@@ -30,10 +30,9 @@ class BaseEncryption implements Encryption {
 	public decrypt(encryptedData: string): string {
 		const decipher = crypto.createDecipheriv(this.algorithm, this.secret, null);
 
-		return decipher.update(
-			encryptedData,
-			this.outputEncoding,
-			this.inputEncoding,
+		return (
+			decipher.update(encryptedData, this.outputEncoding, this.inputEncoding) +
+			decipher.final(this.inputEncoding)
 		);
 	}
 


### PR DESCRIPTION
- changed decryption function
(after reloading the project page, it returns a bad decrypted key, and if you copied it after reloading the page, the key changed to the wrong one.)