### PR TITLE
fix: "Do Not Track" column text wraps onto two lines on smaller screen sizes gf-528

### DIFF
--- a/apps/frontend/src/pages/contributors/libs/helpers/get-contributor-columns/get-contributor-columns.helper.tsx
+++ b/apps/frontend/src/pages/contributors/libs/helpers/get-contributor-columns/get-contributor-columns.helper.tsx
@@ -46,7 +46,7 @@ const getContributorColumns = (actions: {
 			),
 		header: "Do Not Track",
 		id: "hiddenAt",
-		size: 130,
+		size: 140,
 	},
 
 	{


### PR DESCRIPTION
- increased size of "Do Not Track" column (130px -> 140px);

![image](https://github.com/user-attachments/assets/299ae5a0-6d7b-4256-ad2a-0c114d93fab3)