### PR TITLE
fix: inconsistent analytics page elements alignment for the small screen size (1024px) gf-530

### DIFF
--- a/apps/frontend/src/libs/components/date-input/styles.module.css
+++ b/apps/frontend/src/libs/components/date-input/styles.module.css
@@ -98,7 +98,7 @@
 	display: flex;
 	gap: 8px;
 	align-items: center;
-	width: 270px;
+	max-width: 270px;
 	padding: 10px 16px;
 	color: inherit;
 	cursor: pointer;
@@ -120,6 +120,7 @@
 	font-weight: 400;
 	line-height: 1.5;
 	color: inherit;
+	text-overflow: ellipsis;
 	pointer-events: none;
 	background-color: transparent;
 	border: none;

--- a/apps/frontend/src/pages/analytics/analytics.tsx
+++ b/apps/frontend/src/pages/analytics/analytics.tsx
@@ -135,13 +135,15 @@ const Analytics = (): JSX.Element => {
 							placeholder="Select project"
 						/>
 					</div>
-					<DateInput
-						control={control}
-						maxDate={todayDate}
-						maxRange={ANALYTICS_DATE_MAX_RANGE}
-						minDate={minChoosableDate}
-						name="dateRange"
-					/>
+					<div className={styles["date-input-wrapper"]}>
+						<DateInput
+							control={control}
+							maxDate={todayDate}
+							maxRange={ANALYTICS_DATE_MAX_RANGE}
+							minDate={minChoosableDate}
+							name="dateRange"
+						/>
+					</div>
 				</form>
 				<AnalyticsTable
 					activityLogs={activityLogs}

--- a/apps/frontend/src/pages/analytics/libs/components/analytics-contributors-search/styles.module.css
+++ b/apps/frontend/src/pages/analytics/libs/components/analytics-contributors-search/styles.module.css
@@ -1,4 +1,5 @@
 .search-container {
-	width: 300px;
+	width: 100%;
+	max-width: 300px;
 	background-color: var(--color-background-secondary);
 }

--- a/apps/frontend/src/pages/analytics/styles.module.css
+++ b/apps/frontend/src/pages/analytics/styles.module.css
@@ -13,5 +13,11 @@
 }
 
 .select-wrapper {
-	min-width: 270px;
+	width: 100%;
+	max-width: 270px;
+}
+
+.date-input-wrapper {
+	flex-grow: 1;
+	max-width: 270px;
 }


### PR DESCRIPTION
Fixed alignment by creating additional wrapper for date input, also changed limitations for other inputs. If date input has an overflow, it gets hidden with ellipses, done it in order to make placeholders on other inputs completely visible, because the date range can also be viewed when date input is open.

<img width="1428" alt="Screenshot 2024-09-25 at 17 20 44" src="https://github.com/user-attachments/assets/bf302406-ddde-49ff-9490-a5bcf44d1185">
<img width="1680" alt="Screenshot 2024-09-25 at 17 21 28" src="https://github.com/user-attachments/assets/e8c1c0e5-714e-49b2-9c09-16dc59613a83">
