### PR TITLE
fix: incorrect time display and color coding for analytics last sync time gf-547

### DIFF
--- a/packages/shared/src/libs/helpers/get-sync-time/get-sync-time.helper.ts
+++ b/packages/shared/src/libs/helpers/get-sync-time/get-sync-time.helper.ts
@@ -16,7 +16,7 @@ const getSyncTime = (date: Date, baseDate: Date): SyncTimeResult => {
 		return { hoursDifference: ONE_HOUR, label: "1 hour ago" };
 	}
 
-	if (hoursDifference <= HOURS_IN_A_DAY) {
+	if (hoursDifference < HOURS_IN_A_DAY) {
 		return {
 			hoursDifference,
 			label: `${String(hoursDifference)} ${hoursDifference === ONE_HOUR ? "hour" : "hours"} ago`,
@@ -24,6 +24,7 @@ const getSyncTime = (date: Date, baseDate: Date): SyncTimeResult => {
 	}
 
 	return {
+		hoursDifference,
 		label: formatDistance(date, baseDate, { addSuffix: true }),
 	};
 };


### PR DESCRIPTION
When the difference is 24 hours, the text "1 day ago" is displayed and displayed in red color
![image](https://github.com/user-attachments/assets/b7e7c804-5270-460a-90ed-5738d8df9a70)