### PR TITLE
fix: not all contributors are displayed in contributor merge form gf-550

### DIFF
--- a/apps/backend/src/modules/contributors/contributor.controller.ts
+++ b/apps/backend/src/modules/contributors/contributor.controller.ts
@@ -170,13 +170,20 @@ class ContributorController extends BaseController {
 			query: { projectId?: string } & PaginationQueryParameters;
 		}>,
 	): Promise<APIHandlerResponse> {
-		if (options.query.projectId) {
-			const projectId = Number(options.query.projectId);
+		const { page, pageSize, projectId } = options.query;
 
+		if (projectId) {
 			return {
 				payload: await this.contributorService.findAllByProjectId({
-					projectId,
+					projectId: Number(projectId),
 				}),
+				status: HTTPCode.OK,
+			};
+		}
+
+		if (!page || !pageSize) {
+			return {
+				payload: await this.contributorService.findAllWithoutPagination({}),
 				status: HTTPCode.OK,
 			};
 		}

--- a/apps/frontend/src/modules/contributors/contributors-api.ts
+++ b/apps/frontend/src/modules/contributors/contributors-api.ts
@@ -60,6 +60,18 @@ class ContributorApi extends BaseHTTPApi {
 		return await response.json<ContributorGetAllResponseDto>();
 	}
 
+	public async getAllWithoutPagination(): Promise<ContributorGetAllResponseDto> {
+		const response = await this.load(
+			this.getFullEndpoint(ContributorsApiPath.ROOT, {}),
+			{
+				hasAuth: true,
+				method: "GET",
+			},
+		);
+
+		return await response.json<ContributorGetAllResponseDto>();
+	}
+
 	public async merge(
 		id: number,
 		payload: ContributorMergeRequestDto,

--- a/apps/frontend/src/modules/contributors/slices/actions.ts
+++ b/apps/frontend/src/modules/contributors/slices/actions.ts
@@ -27,6 +27,16 @@ const loadAll = createAsyncThunk<
 	return await contributorApi.getAll(query);
 });
 
+const loadAllWithoutPagination = createAsyncThunk<
+	ContributorGetAllResponseDto,
+	undefined,
+	AsyncThunkConfig
+>(`${sliceName}/load-all-without-pagination`, async (_payload, { extra }) => {
+	const { contributorApi } = extra;
+
+	return await contributorApi.getAllWithoutPagination();
+});
+
 const merge = createAsyncThunk<
 	ContributorGetAllItemResponseDto,
 	{ id: number; payload: ContributorMergeRequestDto },
@@ -71,4 +81,4 @@ const patch = createAsyncThunk<
 	},
 );
 
-export { loadAll, merge, patch, split };
+export { loadAll, loadAllWithoutPagination, merge, patch, split };

--- a/apps/frontend/src/modules/contributors/slices/contributors.ts
+++ b/apps/frontend/src/modules/contributors/slices/contributors.ts
@@ -1,9 +1,16 @@
-import { loadAll, merge, patch, split } from "./actions.js";
+import {
+	loadAll,
+	loadAllWithoutPagination,
+	merge,
+	patch,
+	split,
+} from "./actions.js";
 import { actions } from "./contributor.slice.js";
 
 const allActions = {
 	...actions,
 	loadAll,
+	loadAllWithoutPagination,
 	merge,
 	patch,
 	split,

--- a/apps/frontend/src/pages/contributors/contributors.tsx
+++ b/apps/frontend/src/pages/contributors/contributors.tsx
@@ -39,6 +39,8 @@ const Contributors = (): JSX.Element => {
 	const dispatch = useAppDispatch();
 
 	const {
+		allContributors,
+		allContributorsStatus,
 		contributors,
 		dataStatus,
 		mergeContributorsStatus,
@@ -93,10 +95,11 @@ const Contributors = (): JSX.Element => {
 
 	const openMergeModal = useCallback(
 		(contributor: ContributorGetAllItemResponseDto | null) => {
+			void dispatch(contributorActions.loadAllWithoutPagination());
 			setContributorToMerge(contributor);
 			onMergeModalOpen();
 		},
-		[setContributorToMerge, onMergeModalOpen],
+		[dispatch, setContributorToMerge, onMergeModalOpen],
 	);
 
 	const openSplitModal = useCallback(
@@ -218,6 +221,10 @@ const Contributors = (): JSX.Element => {
 	const isLoading =
 		dataStatus === DataStatus.IDLE || dataStatus === DataStatus.PENDING;
 
+	const isLoadingAllContributors =
+		allContributorsStatus === DataStatus.IDLE ||
+		allContributorsStatus === DataStatus.PENDING;
+
 	return (
 		<PageLayout isLoading={isLoading}>
 			<h1 className={styles["title"]}>Contributors</h1>
@@ -255,8 +262,9 @@ const Contributors = (): JSX.Element => {
 					title="Merge contributors"
 				>
 					<ContributorMergeForm
-						allContributors={contributors}
+						allContributors={allContributors}
 						currentContributor={contributorToMerge}
+						isLoading={isLoadingAllContributors}
 						onSubmit={handleContributorMergeSubmit}
 					/>
 				</Modal>

--- a/apps/frontend/src/pages/contributors/contributors.tsx
+++ b/apps/frontend/src/pages/contributors/contributors.tsx
@@ -1,4 +1,5 @@
 import {
+	Loader,
 	Modal,
 	PageLayout,
 	Table,
@@ -261,12 +262,15 @@ const Contributors = (): JSX.Element => {
 					onClose={onMergeModalClose}
 					title="Merge contributors"
 				>
-					<ContributorMergeForm
-						allContributors={allContributors}
-						currentContributor={contributorToMerge}
-						isLoading={isLoadingAllContributors}
-						onSubmit={handleContributorMergeSubmit}
-					/>
+					{isLoadingAllContributors ? (
+						<Loader />
+					) : (
+						<ContributorMergeForm
+							allContributors={allContributors}
+							currentContributor={contributorToMerge}
+							onSubmit={handleContributorMergeSubmit}
+						/>
+					)}
 				</Modal>
 			)}
 			{contributorToSplit && (

--- a/apps/frontend/src/pages/contributors/libs/components/contributor-merge-form/contributor-merge-form.tsx
+++ b/apps/frontend/src/pages/contributors/libs/components/contributor-merge-form/contributor-merge-form.tsx
@@ -1,4 +1,10 @@
-import { Button, Icon, Input, Select } from "~/libs/components/components.js";
+import {
+	Button,
+	Icon,
+	Input,
+	Loader,
+	Select,
+} from "~/libs/components/components.js";
 import { useAppForm, useCallback, useMemo } from "~/libs/hooks/hooks.js";
 import {
 	type ContributorGetAllItemResponseDto,
@@ -12,12 +18,14 @@ import styles from "./styles.module.css";
 type Properties = {
 	allContributors: ContributorGetAllItemResponseDto[];
 	currentContributor: ContributorGetAllItemResponseDto;
+	isLoading?: boolean;
 	onSubmit: (payload: ContributorMergeRequestDto) => void;
 };
 
 const ContributorMergeForm = ({
 	allContributors,
 	currentContributor,
+	isLoading,
 	onSubmit,
 }: Properties): JSX.Element => {
 	const { gitEmails, id, name } = currentContributor;
@@ -55,7 +63,9 @@ const ContributorMergeForm = ({
 		[otherContributors],
 	);
 
-	return (
+	return isLoading ? (
+		<Loader />
+	) : (
 		<form className={styles["form-wrapper"]} onSubmit={handleFormSubmit}>
 			<Input
 				control={control}

--- a/apps/frontend/src/pages/contributors/libs/components/contributor-merge-form/contributor-merge-form.tsx
+++ b/apps/frontend/src/pages/contributors/libs/components/contributor-merge-form/contributor-merge-form.tsx
@@ -1,10 +1,4 @@
-import {
-	Button,
-	Icon,
-	Input,
-	Loader,
-	Select,
-} from "~/libs/components/components.js";
+import { Button, Icon, Input, Select } from "~/libs/components/components.js";
 import { useAppForm, useCallback, useMemo } from "~/libs/hooks/hooks.js";
 import {
 	type ContributorGetAllItemResponseDto,
@@ -18,14 +12,12 @@ import styles from "./styles.module.css";
 type Properties = {
 	allContributors: ContributorGetAllItemResponseDto[];
 	currentContributor: ContributorGetAllItemResponseDto;
-	isLoading?: boolean;
 	onSubmit: (payload: ContributorMergeRequestDto) => void;
 };
 
 const ContributorMergeForm = ({
 	allContributors,
 	currentContributor,
-	isLoading,
 	onSubmit,
 }: Properties): JSX.Element => {
 	const { gitEmails, id, name } = currentContributor;
@@ -63,9 +55,7 @@ const ContributorMergeForm = ({
 		[otherContributors],
 	);
 
-	return isLoading ? (
-		<Loader />
-	) : (
+	return (
 		<form className={styles["form-wrapper"]} onSubmit={handleFormSubmit}>
 			<Input
 				control={control}


### PR DESCRIPTION
* Added action to load all contributors without pagination.
* Refactored contributors page component to use it when merge modal is opened.
![image](https://github.com/user-attachments/assets/bac0fc2d-4307-43ab-9e81-4dbd8cd25b03)
