### PR TITLE
fix: restrict project card visibility based on user permissions gf-558

### DIFF
--- a/apps/backend/src/modules/project-groups/project-group.repository.ts
+++ b/apps/backend/src/modules/project-groups/project-group.repository.ts
@@ -1,6 +1,6 @@
 import { transaction } from "objection";
 
-import { SortType } from "~/libs/enums/enums.js";
+import { ProjectPermissionKey, SortType } from "~/libs/enums/enums.js";
 import { HTTPCode } from "~/libs/modules/http/libs/enums/enums.js";
 import {
 	type PaginationQueryParameters,
@@ -127,7 +127,12 @@ class ProjectGroupRepository implements Repository {
 			.query()
 			.orderBy("createdAt", SortType.DESCENDING)
 			.withGraphJoined("[projects, users, permissions]")
-			.where("users.id", userId);
+			.where("users.id", userId)
+			.andWhere("permissions.key", "in", [
+				ProjectPermissionKey.VIEW_PROJECT,
+				ProjectPermissionKey.EDIT_PROJECT,
+				ProjectPermissionKey.MANAGE_PROJECT,
+			]);
 
 		return results
 			.filter(({ projects }) => projects.length)

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 		},
 		"apps/backend": {
 			"name": "@git-fit/backend",
-			"version": "1.37.0",
+			"version": "1.40.0",
 			"dependencies": {
 				"@fastify/static": "7.0.4",
 				"@fastify/swagger": "8.15.0",
@@ -133,7 +133,7 @@
 		},
 		"apps/frontend": {
 			"name": "@git-fit/frontend",
-			"version": "1.54.0",
+			"version": "1.57.0",
 			"dependencies": {
 				"@git-fit/shared": "*",
 				"@hookform/resolvers": "3.9.0",
@@ -14873,7 +14873,7 @@
 		},
 		"packages/shared": {
 			"name": "@git-fit/shared",
-			"version": "1.34.0",
+			"version": "1.37.0",
 			"dependencies": {
 				"change-case": "5.4.4",
 				"date-fns": "3.6.0",


### PR DESCRIPTION
- Filtered project groups based on user permissions in findAllByUserId.


- Ensured that only project groups with correct permissions are considered when filtering projects.

- Users without sufficient permissions will no longer see unauthorized project cards, improving security and avoiding 404 errors.

![Screenshot 2024-09-27 141115](https://github.com/user-attachments/assets/ea5331f6-d103-4b3d-8a9a-d93139903d3a)
