### PR TITLE
fix: Three Toast notifications are displayed on attempt to open a project page without a permission gf-567

### DIFF
--- a/apps/frontend/src/pages/project/project.tsx
+++ b/apps/frontend/src/pages/project/project.tsx
@@ -119,14 +119,38 @@ const Project = (): JSX.Element => {
 	const [contributorToSplit, setContributorToSplit] =
 		useState<ContributorGetAllItemResponseDto | null>(null);
 
+	const hasViewPermission =
+		checkHasPermission(
+			[PermissionKey.VIEW_ALL_PROJECTS, PermissionKey.MANAGE_ALL_PROJECTS],
+			userPermissions,
+		) ||
+		checkIsProjectPermitted({
+			permission: ProjectPermissionKey.VIEW_PROJECT,
+			projectId,
+			projectUserPermissions,
+		}) ||
+		checkIsProjectPermitted({
+			permission: ProjectPermissionKey.EDIT_PROJECT,
+			projectId,
+			projectUserPermissions,
+		}) ||
+		checkIsProjectPermitted({
+			permission: ProjectPermissionKey.MANAGE_PROJECT,
+			projectId,
+			projectUserPermissions,
+		});
+
 	useEffect(() => {
 		if (projectId) {
 			void dispatch(projectActions.getById({ id: projectId }));
-			void dispatch(
-				projectActions.loadAllContributorsByProjectId(Number(projectId)),
-			);
+
+			if (hasViewPermission) {
+				void dispatch(
+					projectActions.loadAllContributorsByProjectId(Number(projectId)),
+				);
+			}
 		}
-	}, [dispatch, projectId]);
+	}, [dispatch, hasViewPermission, projectId]);
 
 	useEffect(() => {
 		if (projectPatchStatus === DataStatus.FULFILLED) {


### PR DESCRIPTION
* Added has view permission check in order to not load all contributors when user doesn't have neede permissions.
![image](https://github.com/user-attachments/assets/51e4905e-c2d6-4cd5-857a-c9b86192bd0d)
