### PR TITLE
fix: the setup analytics button is not displayed on the page for user with edit project permission for the specific project gf-573

### DIFF
--- a/apps/frontend/src/pages/project/project.tsx
+++ b/apps/frontend/src/pages/project/project.tsx
@@ -321,7 +321,9 @@ const Project = (): JSX.Element => {
 			combinedPermissions,
 		) || hasManagePermission;
 
-	const hasSetupAnalyticsPermission = hasManageAllProjectsPermission;
+	const hasSetupAnalyticsPermission =
+		hasManageAllProjectsPermission || hasEditPermission;
+
 	const hasEditContributorPermission = hasManageAllProjectsPermission;
 	const hasMergeContributorPermission = hasManageAllProjectsPermission;
 	const hasSplitContributorPermission = hasManageAllProjectsPermission;


### PR DESCRIPTION
- updated hasSetupAnalyticsPermission check;

### Screenshots
![image](https://github.com/user-attachments/assets/97335e46-a7d8-4a3b-a534-d75007c50709)
![image](https://github.com/user-attachments/assets/37dc1b04-88fa-4d0f-8df7-1734228bba96)
![image](https://github.com/user-attachments/assets/24f712c7-1282-4a9f-8985-8232bbae1e16)
![image](https://github.com/user-attachments/assets/5440419c-2657-4855-9cee-11284b5d95a1)

