### PR TITLE
fix: the delete project button is displayed and the deletion is accessible for the manage specific project permission gf-570

### DIFF
--- a/apps/backend/src/modules/projects/project.controller.ts
+++ b/apps/backend/src/modules/projects/project.controller.ts
@@ -90,20 +90,7 @@ class ProjectController extends BaseController {
 				),
 			method: "DELETE",
 			path: ProjectsApiPath.$ID,
-			preHandlers: [
-				checkUserPermissions(
-					[PermissionKey.MANAGE_ALL_PROJECTS],
-					[],
-					(options) =>
-						Number(
-							(
-								options as APIHandlerOptions<{
-									params: { id: string };
-								}>
-							).params.id,
-						),
-				),
-			],
+			preHandlers: [checkUserPermissions([PermissionKey.MANAGE_ALL_PROJECTS])],
 		});
 
 		this.addRoute({

--- a/apps/frontend/src/pages/project/libs/components/project-details-menu/project-details-menu.tsx
+++ b/apps/frontend/src/pages/project/libs/components/project-details-menu/project-details-menu.tsx
@@ -60,13 +60,15 @@ const ProjectDetailsMenu = ({
 								iconName="access"
 								label="Manage Access"
 							/>
-							<MenuItem
-								iconName="trashBin"
-								label="Delete"
-								onClick={handleDeleteClick}
-								variant="danger"
-							/>
 						</>
+					)}
+					{hasManageAllProjectsPermission && (
+						<MenuItem
+							iconName="trashBin"
+							label="Delete"
+							onClick={handleDeleteClick}
+							variant="danger"
+						/>
 					)}
 				</Menu>
 			)}

--- a/apps/frontend/src/pages/project/libs/components/project-details-menu/project-details-menu.tsx
+++ b/apps/frontend/src/pages/project/libs/components/project-details-menu/project-details-menu.tsx
@@ -4,8 +4,8 @@ import { configureString } from "~/libs/helpers/helpers.js";
 import { useCallback, usePopover } from "~/libs/hooks/hooks.js";
 
 type Properties = {
+	hasDeleteProjectsPermissions: boolean;
 	hasEditPermission: boolean;
-	hasManageAllProjectsPermission: boolean;
 	hasManagePermission: boolean;
 	onDelete: () => void;
 	onEdit: () => void;
@@ -13,8 +13,8 @@ type Properties = {
 };
 
 const ProjectDetailsMenu = ({
+	hasDeleteProjectsPermissions,
 	hasEditPermission,
-	hasManageAllProjectsPermission,
 	hasManagePermission,
 	onDelete,
 	onEdit,
@@ -40,7 +40,7 @@ const ProjectDetailsMenu = ({
 	);
 
 	const isMenuShown =
-		hasManagePermission || hasEditPermission || hasManageAllProjectsPermission;
+		hasManagePermission || hasEditPermission || hasDeleteProjectsPermissions;
 
 	return (
 		<>
@@ -53,7 +53,7 @@ const ProjectDetailsMenu = ({
 				>
 					<MenuItem iconName="pencil" label="Edit" onClick={handleEditClick} />
 
-					{(hasManagePermission || hasManageAllProjectsPermission) && (
+					{(hasManagePermission || hasDeleteProjectsPermissions) && (
 						<>
 							<MenuItem
 								href={projectAccessManagementRoute}
@@ -62,7 +62,7 @@ const ProjectDetailsMenu = ({
 							/>
 						</>
 					)}
-					{hasManageAllProjectsPermission && (
+					{hasDeleteProjectsPermissions && (
 						<MenuItem
 							iconName="trashBin"
 							label="Delete"

--- a/apps/frontend/src/pages/project/project.tsx
+++ b/apps/frontend/src/pages/project/project.tsx
@@ -315,11 +315,10 @@ const Project = (): JSX.Element => {
 			projectUserPermissions,
 		});
 
-	const hasManageAllProjectsPermission =
-		checkHasPermission(
-			[PermissionKey.MANAGE_ALL_PROJECTS],
-			combinedPermissions,
-		) || hasManagePermission;
+	const hasManageAllProjectsPermission = checkHasPermission(
+		[PermissionKey.MANAGE_ALL_PROJECTS],
+		combinedPermissions,
+	);
 
 	const hasSetupAnalyticsPermission = hasManageAllProjectsPermission;
 	const hasEditContributorPermission = hasManageAllProjectsPermission;

--- a/apps/frontend/src/pages/project/project.tsx
+++ b/apps/frontend/src/pages/project/project.tsx
@@ -315,7 +315,13 @@ const Project = (): JSX.Element => {
 			projectUserPermissions,
 		});
 
-	const hasManageAllProjectsPermission = checkHasPermission(
+	const hasManageAllProjectsPermission =
+		checkHasPermission(
+			[PermissionKey.MANAGE_ALL_PROJECTS],
+			combinedPermissions,
+		) || hasManagePermission;
+
+	const hasDeleteProjectsPermissions = checkHasPermission(
 		[PermissionKey.MANAGE_ALL_PROJECTS],
 		combinedPermissions,
 	);
@@ -357,8 +363,8 @@ const Project = (): JSX.Element => {
 						<div className={styles["project-header"]}>
 							<h1 className={styles["title"]}>{project.name}</h1>
 							<ProjectDetailsMenu
+								hasDeleteProjectsPermissions={hasDeleteProjectsPermissions}
 								hasEditPermission={hasEditPermission}
-								hasManageAllProjectsPermission={hasManageAllProjectsPermission}
 								hasManagePermission={hasManagePermission}
 								onDelete={handleDeleteProject}
 								onEdit={handleEditProject}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 		},
 		"apps/backend": {
 			"name": "@git-fit/backend",
-			"version": "1.40.0",
+			"version": "1.41.0",
 			"dependencies": {
 				"@fastify/static": "7.0.4",
 				"@fastify/swagger": "8.15.0",
@@ -133,7 +133,7 @@
 		},
 		"apps/frontend": {
 			"name": "@git-fit/frontend",
-			"version": "1.57.0",
+			"version": "1.58.0",
 			"dependencies": {
 				"@git-fit/shared": "*",
 				"@hookform/resolvers": "3.9.0",
@@ -14873,7 +14873,7 @@
 		},
 		"packages/shared": {
 			"name": "@git-fit/shared",
-			"version": "1.37.0",
+			"version": "1.38.0",
 			"dependencies": {
 				"change-case": "5.4.4",
 				"date-fns": "3.6.0",


### PR DESCRIPTION
- Removed delete button showing for users with any of the Projectpermissions.
- Adjusted backend to limit deletion for users with Projectpermissions

![Test](https://github.com/user-attachments/assets/594c3710-1084-496c-bced-cc2dfcabc2c5)
