### PR TITLE
fix: Error notification appears when trying delete project which hasn't any project group gf-555

### DIFF
--- a/apps/backend/src/modules/project-groups/project-group.service.ts
+++ b/apps/backend/src/modules/project-groups/project-group.service.ts
@@ -71,17 +71,7 @@ class ProjectGroupService implements Service {
 	}
 
 	public async deleteByProjectId(projectId: number): Promise<boolean> {
-		const isDeleted =
-			await this.projectGroupRepository.deleteByProjectId(projectId);
-
-		if (!isDeleted) {
-			throw new ProjectGroupError({
-				message: ExceptionMessage.PROJECT_GROUP_NOT_FOUND,
-				status: HTTPCode.NOT_FOUND,
-			});
-		}
-
-		return isDeleted;
+		return await this.projectGroupRepository.deleteByProjectId(projectId);
 	}
 
 	public find(): ReturnType<Service["find"]> {


### PR DESCRIPTION
## Changes
- rid of error throwing when project groups were not deleted by project id