### PR TITLE
fix: User with no root permissions is allowed to successfully delete user using Postman gf-583

### DIFF
--- a/apps/backend/src/libs/hooks/check-globa-project-permission.hook.ts
+++ b/apps/backend/src/libs/hooks/check-globa-project-permission.hook.ts
@@ -1,0 +1,52 @@
+import {
+	ExceptionMessage,
+	type PermissionKey,
+	type ProjectPermissionKey,
+} from "~/libs/enums/enums.js";
+import { checkHasPermission } from "~/libs/helpers/helpers.js";
+import { type APIPreHandler } from "~/libs/modules/controller/controller.js";
+import { HTTPCode, HTTPError } from "~/libs/modules/http/http.js";
+import { type UserAuthResponseDto } from "~/modules/users/users.js";
+
+import { type ValueOf } from "../types/types.js";
+
+const checkGlobalOrProjectPermissions = (
+	rootPermissions: ValueOf<typeof PermissionKey>[],
+	projectPermissions: ValueOf<typeof ProjectPermissionKey>[],
+): APIPreHandler => {
+	return (options, done): void => {
+		const user = options.user as UserAuthResponseDto;
+
+		const userPermissions = user.groups.flatMap((group) => group.permissions);
+
+		const hasRootPermission = checkHasPermission(
+			rootPermissions,
+			userPermissions,
+		);
+
+		if (hasRootPermission) {
+			done();
+
+			return;
+		}
+
+		const userProjectPermissions = user.projectGroups.flatMap(
+			(group) => group.permissions,
+		);
+		const hasProjectPermission = checkHasPermission(
+			projectPermissions,
+			userProjectPermissions,
+		);
+
+		if (!hasProjectPermission) {
+			throw new HTTPError({
+				message: ExceptionMessage.NO_PERMISSION,
+				status: HTTPCode.FORBIDDEN,
+			});
+		}
+
+		done();
+	};
+};
+
+export { checkGlobalOrProjectPermissions };

--- a/apps/backend/src/libs/hooks/check-user-permissions.hook.ts
+++ b/apps/backend/src/libs/hooks/check-user-permissions.hook.ts
@@ -1,12 +1,14 @@
 import {
+	ExceptionMessage,
 	type PermissionKey,
 	type ProjectPermissionKey,
 } from "~/libs/enums/enums.js";
-import { checkPermissions } from "~/libs/helpers/helpers.js";
+import { checkHasPermission } from "~/libs/helpers/helpers.js";
 import {
 	type APIHandlerOptions,
 	type APIPreHandler,
 } from "~/libs/modules/controller/controller.js";
+import { HTTPCode, HTTPError } from "~/libs/modules/http/http.js";
 import { type UserAuthResponseDto } from "~/modules/users/users.js";
 
 import { type ValueOf } from "../types/types.js";
@@ -20,12 +22,29 @@ const checkUserPermissions = (
 		const user = options.user as UserAuthResponseDto;
 		const projectId = getProjectId?.(options);
 
-		checkPermissions({
-			projectId: projectId ?? null,
-			projectsPermissions: projectsPermissions ?? null,
-			rootPermissions: permissions,
-			user,
-		});
+		const userPermissions = user.groups.flatMap((group) => group.permissions);
+		const projectPermissions = projectId
+			? user.projectGroups
+					.filter((group) => group.projectId === projectId)
+					.flatMap((projectGroup) => projectGroup.permissions)
+			: [];
+
+		const hasGlobalPermission = checkHasPermission(
+			permissions,
+			userPermissions,
+		);
+
+		const hasProjectPermission =
+			projectId && projectsPermissions
+				? checkHasPermission(projectsPermissions, projectPermissions)
+				: false;
+
+		if (!hasGlobalPermission && (!projectId || !hasProjectPermission)) {
+			throw new HTTPError({
+				message: ExceptionMessage.NO_PERMISSION,
+				status: HTTPCode.FORBIDDEN,
+			});
+		}
 
 		done();
 	};

--- a/apps/backend/src/libs/hooks/hooks.ts
+++ b/apps/backend/src/libs/hooks/hooks.ts
@@ -1,1 +1,2 @@
+export { checkGlobalOrProjectPermissions } from "./check-globa-project-permission.hook.js";
 export { checkUserPermissions } from "./check-user-permissions.hook.js";

--- a/apps/backend/src/modules/activity-logs/activity-log.controller.ts
+++ b/apps/backend/src/modules/activity-logs/activity-log.controller.ts
@@ -4,7 +4,7 @@ import {
 	ProjectPermissionKey,
 } from "~/libs/enums/enums.js";
 import { checkHasPermission } from "~/libs/helpers/helpers.js";
-import { checkUserPermissions } from "~/libs/hooks/hooks.js";
+import { checkGlobalOrProjectPermissions } from "~/libs/hooks/hooks.js";
 import {
 	type APIHandlerOptions,
 	type APIHandlerResponse,
@@ -100,7 +100,7 @@ class ActivityLogController extends BaseController {
 			method: "GET",
 			path: ActivityLogsApiPath.ROOT,
 			preHandlers: [
-				checkUserPermissions(
+				checkGlobalOrProjectPermissions(
 					[PermissionKey.VIEW_ALL_PROJECTS, PermissionKey.MANAGE_ALL_PROJECTS],
 					[
 						ProjectPermissionKey.VIEW_PROJECT,

--- a/apps/backend/src/modules/projects/project.controller.ts
+++ b/apps/backend/src/modules/projects/project.controller.ts
@@ -4,7 +4,10 @@ import {
 	ProjectPermissionKey,
 } from "~/libs/enums/enums.js";
 import { checkHasPermission } from "~/libs/helpers/helpers.js";
-import { checkUserPermissions } from "~/libs/hooks/hooks.js";
+import {
+	checkGlobalOrProjectPermissions,
+	checkUserPermissions,
+} from "~/libs/hooks/hooks.js";
 import {
 	type APIHandlerOptions,
 	type APIHandlerResponse,
@@ -104,13 +107,13 @@ class ProjectController extends BaseController {
 			method: "GET",
 			path: ProjectsApiPath.ROOT,
 			preHandlers: [
-				checkUserPermissions(
-					[PermissionKey.VIEW_ALL_PROJECTS, PermissionKey.MANAGE_ALL_PROJECTS],
+				checkGlobalOrProjectPermissions(
+					[PermissionKey.VIEW_ALL_PROJECTS, PermissionKey.MANAGE_ALL_PROJECTS], // Root permissions
 					[
 						ProjectPermissionKey.VIEW_PROJECT,
 						ProjectPermissionKey.EDIT_PROJECT,
 						ProjectPermissionKey.MANAGE_PROJECT,
-					],
+					], // Project-level permissions
 				),
 			],
 		});

--- a/apps/backend/src/modules/projects/project.controller.ts
+++ b/apps/backend/src/modules/projects/project.controller.ts
@@ -113,7 +113,7 @@ class ProjectController extends BaseController {
 						ProjectPermissionKey.VIEW_PROJECT,
 						ProjectPermissionKey.EDIT_PROJECT,
 						ProjectPermissionKey.MANAGE_PROJECT,
-					], // Project-level permissions
+					],
 				),
 			],
 		});

--- a/apps/backend/src/modules/users/user.controller.ts
+++ b/apps/backend/src/modules/users/user.controller.ts
@@ -4,6 +4,7 @@ import {
 	ProjectPermissionKey,
 } from "~/libs/enums/enums.js";
 import { checkUserPermissions } from "~/libs/hooks/check-user-permissions.hook.js";
+import { checkGlobalOrProjectPermissions } from "~/libs/hooks/hooks.js";
 import {
 	type APIHandlerOptions,
 	type APIHandlerResponse,
@@ -57,7 +58,7 @@ class UserController extends BaseController {
 			method: "GET",
 			path: UsersApiPath.ROOT,
 			preHandlers: [
-				checkUserPermissions(
+				checkGlobalOrProjectPermissions(
 					[PermissionKey.MANAGE_USER_ACCESS, PermissionKey.MANAGE_ALL_PROJECTS],
 					[ProjectPermissionKey.MANAGE_PROJECT],
 				),


### PR DESCRIPTION
Added hook to handle issue with user able to delete groups/users/projects without root permission needed. 


